### PR TITLE
Fix responsive issues: FAQ header, About Us restyle, service breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,15 @@ Hybrid: Bootstrap 5 (grid/utilities), Ant Design (admin components), SCSS (`publ
 ## Environment Variables
 
 See `.env.example` for required variables: Firebase config, DATABASE_URL, Gmail OAuth credentials.
+
+## Playwright / Dev Server Verification
+
+When verifying UI changes with Playwright:
+
+1. **Check if a dev server is already running** before starting one. Use `lsof -ti:3000` to check port 3000. If it's already up, use that session — do not start a new one.
+2. **Only start `yarn dev` if no server is running.** If you do start one, you must kill it when done:
+   ```bash
+   lsof -ti:3000 | xargs kill -9 2>/dev/null; lsof -ti:3001 | xargs kill -9 2>/dev/null
+   ```
+3. **Never leave behind a dev server you started.** If the server was already running before your task, leave it running. Only clean up what you spawned.
+4. **Clean up screenshot files** generated during verification (remove any `.png`/`.jpeg` files created in the project root).

--- a/app/(pages)/about-us/about.module.css
+++ b/app/(pages)/about-us/about.module.css
@@ -1,0 +1,15 @@
+.aboutPage :global(h2),
+.aboutPage :global(h4),
+.aboutPage :global(.about_content .title) {
+  font-family: var(--font-display), sans-serif;
+}
+
+.aboutPage :global(.about-section) {
+  padding-top: 80px;
+}
+
+@media (max-width: 767px) {
+  .aboutPage :global(.about-section) {
+    padding-top: 60px;
+  }
+}

--- a/app/(pages)/about-us/page.js
+++ b/app/(pages)/about-us/page.js
@@ -7,6 +7,7 @@ import WhyChoose from "@/app/components/common/WhyChoose";
 import Testimonial from "@/app/components/common/Testimonial";
 import Map from "@/app/components/common/Map";
 import ReviewBox from "@/app/components/listing/listing-single/ReviewBox";
+import styles from "./about.module.css";
 
 export const metadata = {
   title: "Tentang Kami - Kedai Motor Johor Jaya | Perniagaan Motor Kekal",
@@ -27,7 +28,7 @@ export const metadata = {
 
 const AboutUs = () => {
   return (
-    <div className="wrapper">
+    <div className={`wrapper ${styles.aboutPage}`}>
       {/* header top */}
       <HeaderTop />
       {/* End header top */}
@@ -40,31 +41,9 @@ const AboutUs = () => {
       <MobileMenu />
       {/* End Main Header Nav For Mobile */}
 
-      {/* Inner Page Breadcrumb */}
-      <section className="inner_page_breadcrumb">
-        <div className="container">
-          <div className="row">
-            <div className="col-xl-12">
-              <div className="breadcrumb_content">
-                <h2 className="breadcrumb_title">About Us</h2>
-                <p className="subtitle">About Us</p>
-                <ol className="breadcrumb">
-                  <li className="breadcrumb-item">
-                    <a href="/#">Home</a>
-                  </li>
-                  <li className="breadcrumb-item active" aria-current="page">
-                    <a href="#">About Us</a>
-                  </li>
-                </ol>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-      {/* Inner Page Breadcrumb */}
 
       {/* About Text Content */}
-      <section className="about-section pb130">
+      <section className="about-section pb130 bgc-f9">
         <div className="container">
           <div className="row">
             <AboutTextBlock />
@@ -91,7 +70,7 @@ const AboutUs = () => {
       {/* End Why Chose Us */}
 
       {/* Testimonials  */}
-      <section className="our-testimonials-home1 pt120">
+      <section className="our-testimonials-home1 pt120 bgc-f9">
         <div className="container">
           <div className="row justify-content-center">
             <div className="col-lg-8">
@@ -111,35 +90,41 @@ const AboutUs = () => {
       </section>
       {/* End Testimonials  */}
 
-      <div className="user_profile_location">
-        <h4 className="title">Location</h4>
-        <div className="property_sp_map mb40">
-          <div className="h400 bdrs8 map_in" id="map-canvas">
-            <Map />
+      <section className="user_profile_location">
+        <div className="container">
+          <h4 className="title">Location</h4>
+          <div className="property_sp_map mb40">
+            <div className="h400 bdrs8 map_in" id="map-canvas">
+              <Map />
+            </div>
+          </div>
+          <div className="upl_content d-block d-md-flex">
+            <p className="float-start fn-sm mb20-sm">
+              <span className="fas fa-map-marker-alt pr10 vam" />
+              5, Jln Seroja 49, Taman Johor Bahru, 81100 Johor Bahru, Johor
+            </p>
+            <a
+              href="https://maps.app.goo.gl/a9Fs6RkRSR8dnnsE9"
+              className="btn location_btn"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              target="_blank"
+            >
+              Get Direction
+            </a>
           </div>
         </div>
-        <div className="upl_content d-block d-md-flex">
-          <p className="float-start fn-sm mb20-sm">
-            <span className="fas fa-map-marker-alt pr10 vam" />
-            5, Jln Seroja 49, Taman Johor Bahru, 81100 Johor Bahru, Johor
-          </p>
-          <a
-            href="https://maps.app.goo.gl/a9Fs6RkRSR8dnnsE9"
-            className="btn location_btn"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-            target="_blank"
-          >
-            Get Direction
-          </a>
-        </div>
-      </div>
+      </section>
       {/* End Location */}
 
-      <ReviewBox />
+      <section className="bgc-f9">
+        <div className="container">
+          <ReviewBox />
+        </div>
+      </section>
       {/* End ReviewBox */}
 
       {/* Our Footer */}

--- a/app/faq/faq.module.css
+++ b/app/faq/faq.module.css
@@ -1,6 +1,6 @@
 .faqSection {
   background: #F7F4EE;
-  padding: 60px 0 80px;
+  padding: 100px 0 80px;
   min-height: 60vh;
 }
 
@@ -171,7 +171,7 @@
 
 @media (max-width: 767px) {
   .faqSection {
-    padding: 30px 0 60px;
+    padding: 80px 0 60px;
   }
 
   .heading {

--- a/public/scss/_responsive.scss
+++ b/public/scss/_responsive.scss
@@ -2396,6 +2396,10 @@
   .inner_page_breadcrumb.style2 {
     padding: 20px 0 !important;
   }
+  .inner_page_breadcrumb .breadcrumb_content .breadcrumb {
+    float: none;
+    margin-top: 10px;
+  }
   .main-title h2 {
     font-size: 26px;
   }


### PR DESCRIPTION
## Summary
- **FAQ page**: Fixed header overlapping the "First-time buyer? Start here." heading by increasing section top padding
- **About Us page**: Removed blue breadcrumb banner, applied Space Grotesk font to headings, added alternating grey/white section backgrounds matching the service page layout
- **Service page**: Fixed breadcrumb ("Home / Motorcycle Service") floating right and overlapping the title on mobile viewports (≤767px)
- **CLAUDE.md**: Added dev server cleanup instructions for Playwright verification workflows

## Test plan
- [ ] Verify FAQ page heading is fully visible below header on mobile
- [ ] Verify About Us page has no blue banner and sections alternate grey/white
- [ ] Verify About Us headings use Space Grotesk font
- [ ] Verify Service page breadcrumb stacks below title on mobile
- [ ] Check desktop views are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)