### PR TITLE
Feat: SEO schema improvements — ItemList, FAQPage, LocalBusiness

### DIFF
--- a/app/(listing)/(listing-styles)/listing/layout.js
+++ b/app/(listing)/(listing-styles)/listing/layout.js
@@ -1,3 +1,5 @@
+import ItemListSchema from "@/app/components/seo/ItemListSchema";
+
 export const metadata = {
   title: "Jual Motor Baru Johor Bahru - Yamaha, Kawasaki, Honda, KTM",
   description:
@@ -26,6 +28,11 @@ export const metadata = {
   },
 };
 
-export default function ListingLayout({ children }) {
-  return children;
+export default async function ListingLayout({ children }) {
+  return (
+    <>
+      <ItemListSchema />
+      {children}
+    </>
+  );
 }

--- a/app/components/seo/ItemListSchema.js
+++ b/app/components/seo/ItemListSchema.js
@@ -1,0 +1,33 @@
+import { listMotorcyclesPg } from "@/utils/dbPg";
+import { toMotorcycleSlug } from "@/utils/slug";
+
+const ItemListSchema = async () => {
+  try {
+    const motorcycles = await listMotorcyclesPg();
+
+    const itemListData = {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "Motorcycles for Sale — Perniagaan Motor Kekal, Johor Bahru",
+      url: "https://www.motorkekal.com/listing",
+      numberOfItems: motorcycles.length,
+      itemListElement: motorcycles.slice(0, 20).map((moto, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `https://www.motorkekal.com/motorcycle/${toMotorcycleSlug(moto)}`,
+        name: moto.name,
+      })),
+    };
+
+    return (
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListData) }}
+      />
+    );
+  } catch {
+    return null;
+  }
+};
+
+export default ItemListSchema;

--- a/app/components/seo/LocalBusinessSchema.js
+++ b/app/components/seo/LocalBusinessSchema.js
@@ -40,9 +40,13 @@ const localBusinessData = {
   ],
   image:
     "https://www.motorkekal.com/images/background/website-screenshot.jpeg",
+  foundingDate: "1992-07-13",
   priceRange: "RM",
   hasMap: "https://maps.app.goo.gl/a9Fs6RkRSR8dnnsE9",
-  sameAs: ["https://www.facebook.com/PerniagaanMotorKekal/"],
+  sameAs: [
+    "https://www.facebook.com/PerniagaanMotorKekal/",
+    "https://maps.app.goo.gl/a9Fs6RkRSR8dnnsE9",
+  ],
 };
 
 const LocalBusinessSchema = () => {

--- a/app/faq/page.js
+++ b/app/faq/page.js
@@ -67,6 +67,21 @@ const FAQ_DATA = {
 
 const CATEGORIES = Object.keys(FAQ_DATA);
 
+const faqSchemaData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: Object.values(FAQ_DATA)
+    .flat()
+    .map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+};
+
 export default function FAQPage() {
   const [activeCategory, setActiveCategory] = useState(CATEGORIES[0]);
   const [openIndex, setOpenIndex] = useState(0);
@@ -75,6 +90,10 @@ export default function FAQPage() {
 
   return (
     <div className="wrapper">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchemaData) }}
+      />
       <HeaderTop />
       <DefaultHeader />
       <MobileMenu />

--- a/app/layout.js
+++ b/app/layout.js
@@ -33,6 +33,8 @@ export const metadata = {
     "motor shop near me",
     "kedai motor jb",
     "motorbike shop johor bahru",
+    "motor jb",
+    "jual motor jb",
   ],
   authors: [{ name: "Perniagaan Motor Kekal" }],
   creator: "Perniagaan Motor Kekal",


### PR DESCRIPTION
## Summary

- **ItemList schema** on `/listing` — server-rendered JSON-LD listing up to 20 motorcycles from live inventory; enables Google to surface motorcycle names directly in search snippets
- **FAQPage schema** on `/faq` — marks up all 10 Q&As across Financing, Delivery, and Warranty categories; eligible for Google's Q&A rich result panel / featured snippets
- **LocalBusinessSchema** — added `foundingDate: "1992-07-13"` (33 years of operation is a strong trust signal) and Google Maps URL to `sameAs` array
- **Root metadata keywords** — added `"motor jb"` and `"jual motor jb"` to target the primary search query

## Test plan

- [ ] Visit `/listing` and inspect page source for `"@type": "ItemList"` JSON-LD block
- [ ] Visit `/faq` and inspect page source for `"@type": "FAQPage"` JSON-LD block
- [ ] Validate schemas at [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm `LocalBusinessSchema` includes `foundingDate` and updated `sameAs` in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)