### PR TITLE
Replace dummy testimonials with real Google reviews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ DEFAULT_FROM_NAME=Kekal Team
 
 # Admin email for receiving contact forms and notifications (your email)
 ADMIN_EMAIL=kaicong12@gmail.com
+
+# Google Places API (New) — used only by utils/scripts/fetch-reviews.mjs to
+# refresh app/data/testimonials.json. Not called at runtime. Requires Places
+# API (New) enabled + billing on the same project as the key.
+GOOGLE_PLACES_API_KEY=your-places-api-key
+# Optional: skip the place lookup by pinning the Place ID, or change the search text.
+# GOOGLE_PLACE_ID=ChIJfZsu_RRs2jER3pOUeexSuSQ
+# GOOGLE_PLACES_QUERY=Perniagaan Motor Kekal Taman Johor Jaya

--- a/app/components/common/InitialsAvatar.js
+++ b/app/components/common/InitialsAvatar.js
@@ -1,0 +1,53 @@
+// Deterministic, faceless avatar for review authors: a colored circle with the
+// reviewer's initials. Avoids fake stock-photo faces and re-hosting Google
+// profile photos, while staying visually consistent across testimonials.
+
+const PALETTE = [
+  "#1d4ed8",
+  "#0f766e",
+  "#b45309",
+  "#9333ea",
+  "#be123c",
+  "#15803d",
+  "#0369a1",
+  "#c2410c",
+];
+
+function colorFor(seed) {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return PALETTE[hash % PALETTE.length];
+}
+
+const InitialsAvatar = ({ name, initials, size = 70, style }) => {
+  const label = initials || (name ? name.trim().charAt(0).toUpperCase() : "?");
+  return (
+    <span
+      aria-label={name}
+      title={name}
+      style={{
+        width: size,
+        height: size,
+        flex: "0 0 auto",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: "50%",
+        background: colorFor(name || label),
+        color: "#fff",
+        fontWeight: 700,
+        fontSize: Math.round(size * 0.36),
+        lineHeight: 1,
+        letterSpacing: "0.5px",
+        userSelect: "none",
+        ...style,
+      }}
+    >
+      {label}
+    </span>
+  );
+};
+
+export default InitialsAvatar;

--- a/app/components/common/StarRating.js
+++ b/app/components/common/StarRating.js
@@ -1,0 +1,22 @@
+// Simple 5-star rating using Font Awesome icons (already loaded project-wide).
+
+const StarRating = ({ rating = 5, size }) => {
+  const rounded = Math.round(rating);
+  return (
+    <span
+      className="star-rating"
+      aria-label={`${rating} out of 5 stars`}
+      style={{ color: "#fbbf24", fontSize: size }}
+    >
+      {[1, 2, 3, 4, 5].map((i) => (
+        <span
+          key={i}
+          className={i <= rounded ? "fas fa-star" : "far fa-star"}
+          style={{ marginRight: 2 }}
+        />
+      ))}
+    </span>
+  );
+};
+
+export default StarRating;

--- a/app/components/common/Testimonial.js
+++ b/app/components/common/Testimonial.js
@@ -2,38 +2,11 @@
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination } from "swiper";
 import "swiper/swiper-bundle.css";
-import Image from "next/image";
+import InitialsAvatar from "./InitialsAvatar";
+import StarRating from "./StarRating";
+import reviewsData from "@/app/data/testimonials.json";
 
-const testimonials = [
-  {
-    id: 1,
-    name: "Ahmad Fauzi",
-    title: "Motorcycle Enthusiast",
-    text: "Outstanding service and genuine parts! I've been riding for 15 years and this is the best motorcycle shop I've ever dealt with. They helped me find the perfect exhaust system for my Yamaha R1 and the installation was flawless.",
-    image: "/images/testimonial/avatar-af.svg",
-  },
-  {
-    id: 2,
-    name: "Nurul Aina",
-    title: "Daily Commuter",
-    text: "My Honda CB650R needed urgent repairs and they had me back on the road the same day. The staff really knows their motorcycles and the prices are very reasonable. I wouldn't trust my bike with anyone else!",
-    image: "/images/testimonial/avatar-na.svg",
-  },
-  {
-    id: 3,
-    name: "Raj Kumar Selvam",
-    title: "Motorcycle Enthusiast",
-    text: "Incredible selection of motorcycle gear and accessories! From helmets to riding jackets, they have everything a rider needs. The quality is top-notch and their advice on safety gear is invaluable.",
-    image: "/images/testimonial/avatar-rs.svg",
-  },
-  {
-    id: 4,
-    name: "Tan Mei Ling",
-    title: "Daily Commuter",
-    text: "Fast shipping and excellent customer service. Ordered brake pads online and they arrived within 2 days. The online store is easy to navigate and they have detailed product descriptions that helped me choose the right parts.",
-    image: "/images/testimonial/avatar-tm.svg",
-  },
-];
+const testimonials = reviewsData.reviews;
 
 const Testimonial = () => {
   return (
@@ -64,27 +37,44 @@ const Testimonial = () => {
           },
         }}
       >
-        {testimonials.map((testimonial) => (
-          <SwiperSlide key={testimonial.id}>
+        {testimonials.map((testimonial, i) => (
+          <SwiperSlide key={i}>
             <div className="testimonial_box">
-              <div className="thumb">
-                <Image
-                  width={70}
-                  height={70}
-                  className="rounded-circle"
-                  src={testimonial.image}
-                  alt={testimonial.name}
+              <div
+                className="thumb"
+                style={{ display: "flex", alignItems: "center", gap: 16 }}
+              >
+                <InitialsAvatar
+                  name={testimonial.author}
+                  initials={testimonial.initials}
                 />
-                <h4 className="title">
-                  {testimonial.name} <br />
-                  <small>{testimonial.title}</small>
+                <h4 className="title" style={{ margin: 0 }}>
+                  {testimonial.author}
+                  <span style={{ display: "block", marginTop: 6 }}>
+                    <StarRating rating={testimonial.rating} />
+                  </span>
                 </h4>
               </div>
               <div className="details">
                 <div className="icon">
                   <span className="fa fa-quote-left" />
                 </div>
-                <p>{testimonial.text}</p>
+                <p lang={testimonial.languageCode}>{testimonial.text}</p>
+                <a
+                  href={testimonial.reviewUri || reviewsData.googleMapsUri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    fontSize: 13,
+                    color: "#6b7280",
+                  }}
+                >
+                  <span className="fab fa-google" /> Posted on Google
+                  {testimonial.relativeTime ? ` · ${testimonial.relativeTime}` : ""}
+                </a>
               </div>
             </div>
           </SwiperSlide>

--- a/app/components/home/Testimonial.js
+++ b/app/components/home/Testimonial.js
@@ -1,32 +1,9 @@
-import Image from "next/image";
+import InitialsAvatar from "@/app/components/common/InitialsAvatar";
+import StarRating from "@/app/components/common/StarRating";
+import reviewsData from "@/app/data/testimonials.json";
 
 const Testimonial = () => {
-  const testimonialsData = [
-    {
-      id: "1",
-      name: "Rajesh Kumar",
-      role: "Professional Rider",
-      imageSrc: "/images/testimonial/avatar-rk.svg",
-      quote:
-        "As a professional delivery rider, I depend on my motorcycle daily. This shop has kept my Honda Wave running perfectly for over 3 years. Their maintenance service is exceptional and they always use genuine parts. The team understands the demands of commercial riding!",
-    },
-    {
-      id: "2",
-      name: "Chen Siew Fong",
-      role: "Motorcycle Collector",
-      imageSrc: "/images/testimonial/avatar-cs.svg",
-      quote:
-        "I own several vintage motorcycles and finding the right parts can be challenging. This shop has an incredible network and always manages to source exactly what I need. Their expertise with classic bikes is unmatched - they've restored my 1985 Kawasaki Ninja to perfection!",
-    },
-    {
-      id: "3",
-      name: "Sharifah Amina",
-      role: "Adventure Rider",
-      imageSrc: "/images/testimonial/avatar-sa.svg",
-      quote:
-        "Before my long-distance touring trips, I always bring my BMW GS here for a complete check-up. Their attention to detail gives me confidence on the road. They've equipped my bike with the best touring accessories and their advice on gear selection is invaluable for adventure riding!",
-    },
-  ];
+  const testimonialsData = reviewsData.reviews;
 
   return (
     <>
@@ -36,19 +13,37 @@ const Testimonial = () => {
         data-aos-delay="100"
       >
         <div className="tab-content" id="pills-tabContent2">
-          {testimonialsData.map((testimonial) => (
+          {testimonialsData.map((testimonial, i) => (
             <div
-              key={testimonial.id}
-              className={`tab-pane fade ${
-                testimonial.id === "2" ? "show active" : ""
-              }`}
-              id={`pills-${testimonial.id}`}
+              key={i}
+              className={`tab-pane fade ${i === 0 ? "show active" : ""}`}
+              id={`pills-${i}`}
               role="tabpanel"
-              aria-labelledby={`pills-${testimonial.id}-tab`}
+              aria-labelledby={`pills-${i}-tab`}
             >
               <div className="testimonial_post_home2 text-center">
                 <div className="details">
-                  <p>{testimonial.quote}</p>
+                  <div className="mb15">
+                    <StarRating rating={testimonial.rating} />
+                  </div>
+                  <p lang={testimonial.languageCode}>{testimonial.text}</p>
+                  <a
+                    href={testimonial.reviewUri || reviewsData.googleMapsUri}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 6,
+                      fontSize: 13,
+                      color: "#6b7280",
+                    }}
+                  >
+                    <span className="fab fa-google" /> Posted on Google
+                    {testimonial.relativeTime
+                      ? ` · ${testimonial.relativeTime}`
+                      : ""}
+                  </a>
                 </div>
               </div>
             </div>
@@ -61,30 +56,30 @@ const Testimonial = () => {
           id="pills-tab2"
           role="tablist"
         >
-          {testimonialsData.map((testimonial) => (
-            <li className="nav-item" role="presentation" key={testimonial.id}>
+          {testimonialsData.map((testimonial, i) => (
+            <li className="nav-item" role="presentation" key={i}>
               <a
-                className={`nav-link ${testimonial.id === "2" ? "active" : ""}`}
-                id={`pills-${testimonial.id}-tab`}
+                className={`nav-link ${i === 0 ? "active" : ""}`}
+                id={`pills-${i}-tab`}
                 data-bs-toggle="pill"
-                href={`#pills-${testimonial.id}`}
+                href={`#pills-${i}`}
                 role="tab"
-                aria-controls={`pills-${testimonial.id}`}
-                aria-selected={testimonial.id === "2" ? "true" : "false"}
+                aria-controls={`pills-${i}`}
+                aria-selected={i === 0 ? "true" : "false"}
               >
-                <div className="thumb d-inline-flex">
-                  <Image
-                    width={70}
-                    height={70}
-                    priority
-                    className="rounded-circle"
-                    src={testimonial.imageSrc}
-                    alt={testimonial.name}
+                <div
+                  className="thumb d-inline-flex"
+                  style={{ alignItems: "center", gap: 16, textAlign: "left" }}
+                >
+                  <InitialsAvatar
+                    name={testimonial.author}
+                    initials={testimonial.initials}
                   />
-                  <h4 className="title">
-                    {testimonial.name}
-                    <br />
-                    <small>{testimonial.role}</small>
+                  <h4 className="title" style={{ margin: 0 }}>
+                    {testimonial.author}
+                    <span style={{ display: "block", marginTop: 4 }}>
+                      <small>{testimonial.relativeTime}</small>
+                    </span>
                   </h4>
                 </div>
               </a>

--- a/app/data/testimonials.json
+++ b/app/data/testimonials.json
@@ -1,0 +1,61 @@
+{
+  "placeId": "ChIJfZsu_RRs2jER3pOUeexSuSQ",
+  "placeName": "Perniagaan Motor Kekal",
+  "rating": 4.3,
+  "userRatingCount": 31,
+  "googleMapsUri": "https://maps.google.com/?cid=2646237431662416862&g_mp=CiVnb29nbGUubWFwcy5wbGFjZXMudjEuUGxhY2VzLkdldFBsYWNlEAIYBCAA",
+  "fetchedAt": "2026-06-05T09:13:28.230Z",
+  "source": "Google Places API",
+  "reviews": [
+    {
+      "author": "Haikal Carlos",
+      "initials": "HC",
+      "rating": 5,
+      "text": "I've got a nice ride from this shop",
+      "languageCode": "en",
+      "textEn": "I've got a nice ride from this shop",
+      "relativeTime": "4 years ago",
+      "reviewUri": "https://www.google.com/maps/reviews/data=!4m6!14m5!1m4!2m3!1sChdDSUhNMG9nS0VJQ0FnSURXbXZDeHJBRRAB!2m1!1s0x31da6c14fd2e9b7d:0x24b952ec799493de"
+    },
+    {
+      "author": "Norhisham Hassan",
+      "initials": "NH",
+      "rating": 4,
+      "text": "Senang berurusan.. Loan motor baru mudah lulus",
+      "languageCode": "ms",
+      "textEn": "Easy to deal with.. New motor loan is easy to pass",
+      "relativeTime": "4 years ago",
+      "reviewUri": "https://www.google.com/maps/reviews/data=!4m6!14m5!1m4!2m3!1sChdDSUhNMG9nS0VJQ0FnSURhcHQtc3p3RRAB!2m1!1s0x31da6c14fd2e9b7d:0x24b952ec799493de"
+    },
+    {
+      "author": "zamri zamri",
+      "initials": "ZZ",
+      "rating": 5,
+      "text": "Layanan dengan costemer bagus",
+      "languageCode": "ms",
+      "textEn": "Good customer service",
+      "relativeTime": "6 years ago",
+      "reviewUri": "https://www.google.com/maps/reviews/data=!4m6!14m5!1m4!2m3!1sChdDSUhNMG9nS0VJQ0FnSUNrNmR5Rmp3RRAB!2m1!1s0x31da6c14fd2e9b7d:0x24b952ec799493de"
+    },
+    {
+      "author": "MIOW KIUM LEE",
+      "initials": "MK",
+      "rating": 4,
+      "text": "服務好。",
+      "languageCode": "zh-Hant",
+      "textEn": "Good service.",
+      "relativeTime": "7 years ago",
+      "reviewUri": "https://www.google.com/maps/reviews/data=!4m6!14m5!1m4!2m3!1sChdDSUhNMG9nS0VJQ0FnSUNvODhHXzlnRRAB!2m1!1s0x31da6c14fd2e9b7d:0x24b952ec799493de"
+    },
+    {
+      "author": "kit lee",
+      "initials": "KL",
+      "rating": 5,
+      "text": "很好说话的老板",
+      "languageCode": "zh",
+      "textEn": "A very easy-going boss",
+      "relativeTime": "4 years ago",
+      "reviewUri": "https://www.google.com/maps/reviews/data=!4m6!14m5!1m4!2m3!1sChdDSUhNMG9nS0VJQ0FnSURXM3FIWDZBRRAB!2m1!1s0x31da6c14fd2e9b7d:0x24b952ec799493de"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",
+    "reviews:fetch": "node utils/scripts/fetch-reviews.mjs",
     "prepare": "husky"
   },
   "dependencies": {

--- a/utils/scripts/fetch-reviews.mjs
+++ b/utils/scripts/fetch-reviews.mjs
@@ -1,0 +1,133 @@
+import "dotenv/config";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * One-time / on-demand fetch of Google reviews via the Places API (New).
+ *
+ * Writes the meaningful reviews to app/data/testimonials.json, which the
+ * Testimonial components render at build/runtime. The site never calls Google
+ * directly — re-run this script whenever you want to refresh the snapshot:
+ *
+ *   node utils/scripts/fetch-reviews.mjs           # or: yarn reviews:fetch
+ *
+ * Requires GOOGLE_PLACES_API_KEY in .env (Places API (New) enabled, billing on).
+ * Optionally set GOOGLE_PLACE_ID to skip the lookup, or GOOGLE_PLACES_QUERY to
+ * change the search text used to find the listing.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUTPUT = path.resolve(__dirname, "../../app/data/testimonials.json");
+
+const API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+const PLACE_QUERY =
+  process.env.GOOGLE_PLACES_QUERY || "Perniagaan Motor Kekal Taman Johor Jaya";
+let PLACE_ID = process.env.GOOGLE_PLACE_ID || "";
+
+// "Meaningful" filter: keep positive reviews that actually have text.
+const MIN_RATING = 4;
+const MIN_TEXT_LENGTH = 1;
+
+if (!API_KEY) {
+  console.error(
+    "Missing GOOGLE_PLACES_API_KEY in .env (Places API (New), billing enabled)."
+  );
+  process.exit(1);
+}
+
+async function findPlaceId() {
+  const res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": API_KEY,
+      "X-Goog-FieldMask":
+        "places.id,places.displayName,places.formattedAddress",
+    },
+    body: JSON.stringify({ textQuery: PLACE_QUERY }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.error?.message || JSON.stringify(data));
+  const place = data.places?.[0];
+  if (!place) throw new Error(`No place found for query: "${PLACE_QUERY}"`);
+  console.log(`Matched: ${place.displayName?.text} — ${place.formattedAddress}`);
+  return place.id;
+}
+
+async function fetchPlace(placeId) {
+  const res = await fetch(
+    `https://places.googleapis.com/v1/places/${placeId}?languageCode=en`,
+    {
+      headers: {
+        "X-Goog-Api-Key": API_KEY,
+        "X-Goog-FieldMask":
+          "id,displayName,rating,userRatingCount,googleMapsUri,reviews",
+      },
+    }
+  );
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.error?.message || JSON.stringify(data));
+  return data;
+}
+
+function initials(name) {
+  return (
+    name
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((w) => w[0]?.toUpperCase() || "")
+      .join("") || "?"
+  );
+}
+
+async function main() {
+  if (!PLACE_ID) PLACE_ID = await findPlaceId();
+  const place = await fetchPlace(PLACE_ID);
+
+  const reviews = (place.reviews || [])
+    .filter((r) => (r.rating ?? 0) >= MIN_RATING)
+    .map((r) => {
+      // Show the review in the language the customer actually wrote it in.
+      const original = r.originalText || r.text || {};
+      const english = r.text || {};
+      const author = r.authorAttribution?.displayName || "Google user";
+      return {
+        author,
+        initials: initials(author),
+        rating: r.rating,
+        text: (original.text || "").trim(),
+        languageCode: original.languageCode || "en",
+        textEn: (english.text || "").trim(),
+        relativeTime: r.relativePublishTimeDescription || "",
+        reviewUri: r.googleMapsUri || "",
+      };
+    })
+    .filter((r) => r.text.length >= MIN_TEXT_LENGTH);
+
+  const out = {
+    placeId: PLACE_ID,
+    placeName: place.displayName?.text || "",
+    rating: place.rating ?? null,
+    userRatingCount: place.userRatingCount ?? null,
+    googleMapsUri: place.googleMapsUri || "",
+    fetchedAt: new Date().toISOString(),
+    source: "Google Places API",
+    reviews,
+  };
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(out, null, 2) + "\n");
+  console.log(
+    `Wrote ${reviews.length} review(s) to ${path.relative(
+      process.cwd(),
+      OUTPUT
+    )}`
+  );
+}
+
+main().catch((err) => {
+  console.error("Failed to fetch reviews:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Replaces the hardcoded placeholder testimonials with **real Google reviews** for Perniagaan Motor Kekal, on both the home page and the About Us page.

Reviews are fetched **once** via the Google Places API (New) into a static `app/data/testimonials.json`. The site reads that JSON — it never calls Google at runtime (no per-load cost/latency). A re-runnable script refreshes the snapshot when you want:

```
yarn reviews:fetch   # node utils/scripts/fetch-reviews.mjs
```

## What changed
| File | Purpose |
|---|---|
| `utils/scripts/fetch-reviews.mjs` | Fetch + filter reviews → JSON (re-runnable) |
| `app/data/testimonials.json` | The 5 real reviews (static, committed) |
| `app/components/common/InitialsAvatar.js` | Faceless colored-initials avatar (no fake faces / no re-hosting Google photos) |
| `app/components/common/StarRating.js` | ★ rating |
| `app/components/home/Testimonial.js` | Tabbed section → renders from JSON |
| `app/components/common/Testimonial.js` | About-us carousel → renders from JSON |
| `.env.example` | Documents `GOOGLE_PLACES_API_KEY` (script-only) |
| `package.json` | Adds `reviews:fetch` script |

## Notes / honest caveats
- **5 reviews max.** That's Google's hard cap via the official API. All 5 are 4–5★, shown in the customer's **original language** (BM / Chinese / English).
- Reviews are **brief and a few years old** — that's the authentic state of the listing, not a bug. Chose real-but-short over fabricated.
- **Attribution** (reviewer name + "Posted on Google") is shown per review, per Google's terms. Content is a point-in-time snapshot; re-run the script to refresh.
- `GOOGLE_PLACES_API_KEY` lives in `.env` (git-ignored) and is **only** used by the script, never at runtime.

## Test plan
- [ ] Home page "Our Testimonials" shows the 5 reviewer tabs + active quote with stars
- [ ] About Us "Testimonials" carousel shows the reviews with avatars/stars
- [ ] Avatar spacing looks right next to name/stars
- [ ] `yarn reviews:fetch` regenerates `app/data/testimonials.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)