### PR TITLE
feat: home featured promotions, promotions improvements & keyless admin auth

### DIFF
--- a/app/[locale]/(pages)/promotions/page.js
+++ b/app/[locale]/(pages)/promotions/page.js
@@ -38,11 +38,13 @@ const Promotions = async ({ params: { locale } }) => {
     listPastPromotionsPg({ limit: 6 }).catch(() => []),
   ]);
 
-  const featured =
-    livePromotions.find((p) => p.isFeatured) || livePromotions[0] || null;
-  const rest = livePromotions.filter((p) => p.id !== featured?.id);
+  // All featured promos become hero cards; non-featured live promos go to
+  // "More offers". No fallback — if nothing is featured, no hero is shown.
+  const featuredPromotions = livePromotions.filter((p) => p.isFeatured);
+  const rest = livePromotions.filter((p) => !p.isFeatured);
 
-  const monthLabel = (featured ? new Date(featured.startDate) : new Date())
+  const labelPromotion = featuredPromotions[0] || livePromotions[0];
+  const monthLabel = (labelPromotion ? new Date(labelPromotion.startDate) : new Date())
     .toLocaleDateString(locale === "en" ? "en-US" : locale, {
       month: "short",
       year: "numeric",
@@ -68,9 +70,11 @@ const Promotions = async ({ params: { locale } }) => {
             : t("summaryEmpty")}
         </p>
 
-        {featured ? (
+        {livePromotions.length > 0 ? (
           <>
-            <FeaturedPromoCard promotion={featured} />
+            {featuredPromotions.map((promotion) => (
+              <FeaturedPromoCard key={promotion.id} promotion={promotion} />
+            ))}
 
             {rest.length > 0 && (
               <>

--- a/app/[locale]/home/page.js
+++ b/app/[locale]/home/page.js
@@ -1,6 +1,7 @@
 import MobileMenu from "@/app/components/common/MobileMenu";
 import WhyChoose from "@/app/components/common/WhyChoose";
 import FeaturedFilterListing from "@/app/components/home/FeaturedFilterListing";
+import FeaturedPromotions from "@/app/components/home/FeaturedPromotions";
 import Footer from "@/app/components/home/Footer";
 import Header from "@/app/components/home/Header";
 import Hero from "@/app/components/home/Hero";
@@ -49,6 +50,10 @@ const Home = ({ params }) => {
         </div>
       </section>
       {/* End Quick Quote Wizard */}
+
+      {/* Featured Promotions (renders nothing when none are featured) */}
+      <FeaturedPromotions />
+      {/* End Featured Promotions */}
 
       {/* Why Choose Us */}
       <section className="whychose_us pb70 pt0">

--- a/app/components/admin/promotions/PromotionListInterface.js
+++ b/app/components/admin/promotions/PromotionListInterface.js
@@ -158,7 +158,9 @@ export default function PromotionListInterface({ onCreateNew, onEdit }) {
       key: "actions",
       width: 120,
       render: (_, record) => (
-        <Space>
+        // Stop propagation so the buttons don't also trigger the row's
+        // onClick (which opens the edit page).
+        <Space onClick={(e) => e.stopPropagation()}>
           <Button
             type="primary"
             size="small"
@@ -214,6 +216,10 @@ export default function PromotionListInterface({ onCreateNew, onEdit }) {
           loading={loading}
           pagination={{ pageSize: 10, showSizeChanger: true }}
           scroll={{ x: 700 }}
+          onRow={(record) => ({
+            onClick: () => onEdit(record.id),
+            style: { cursor: "pointer" },
+          })}
         />
       </Card>
     </div>

--- a/app/components/home/FeaturedPromotions.js
+++ b/app/components/home/FeaturedPromotions.js
@@ -1,0 +1,123 @@
+"use client";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { Link } from "@/i18n/navigation";
+import { useTranslations, useLocale } from "next-intl";
+import {
+  whatsappLink,
+  daysLeft,
+  formatOfferDate,
+} from "@/app/components/pages/promotions/promoUtils";
+import styles from "./FeaturedPromotions.module.css";
+
+const PLACEHOLDER = "/images/no-image.svg";
+
+const FeaturedPromotions = () => {
+  const t = useTranslations();
+  const locale = useLocale();
+  const [promotions, setPromotions] = useState([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/promotions")
+      .then((res) => (res.ok ? res.json() : { promotions: [] }))
+      .then((data) => {
+        if (!active) return;
+        // Only featured promos appear on the home page.
+        setPromotions((data.promotions || []).filter((p) => p.isFeatured));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setLoaded(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Render nothing until loaded, and nothing when there are no featured promos.
+  if (!loaded || promotions.length === 0) return null;
+
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className="row justify-content-center">
+          <div className="col-lg-8">
+            <div className="main-title text-center">
+              <h2>{t("home.promotionsHeading")}</h2>
+              <p className={styles.subtitle}>{t("home.promotionsSubtitle")}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="row car-listing-grid">
+          {promotions.map((promo) => {
+            const remaining = daysLeft(promo.endDate);
+            const badge =
+              remaining <= 1
+                ? t("promotions.endsToday")
+                : t("promotions.endsInDays", { count: remaining });
+            const image =
+              promo.imageUrl || promo.motorcycle?.imageUrl || PLACEHOLDER;
+
+            return (
+              <div className="col-sm-6 col-lg-4" key={promo.id}>
+                <div className="car-listing">
+                  <div className="thumb">
+                    <span className={styles.badge}>{badge}</span>
+                    <Image
+                      width={284}
+                      height={183}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                      }}
+                      src={image}
+                      alt={promo.title}
+                    />
+                  </div>
+                  <div className="details">
+                    <h6 className="card-title">{promo.title}</h6>
+                    {promo.subtitle && (
+                      <p className={styles.cardSubtitle}>{promo.subtitle}</p>
+                    )}
+                    <p className={styles.ends}>
+                      {t("promotions.offerEnds", {
+                        date: formatOfferDate(promo.endDate, locale),
+                      })}
+                    </p>
+                    <a
+                      href={whatsappLink(promo)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="view-details-btn"
+                    >
+                      {promo.ctaText || t("promotions.claimDeal")}
+                    </a>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="row mt20">
+          <div className="col-lg-12">
+            <div className="text-center">
+              <Link href="/promotions" className="more_listing">
+                {t("home.viewAllPromotions")}{" "}
+                <span className="icon">
+                  <span className="fas fa-plus" />
+                </span>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FeaturedPromotions;

--- a/app/components/home/FeaturedPromotions.module.css
+++ b/app/components/home/FeaturedPromotions.module.css
@@ -1,0 +1,46 @@
+/* Featured promotions on the home page. Reuses the global .car-listing card
+   styles for consistency; these rules cover only the promo-specific bits. */
+
+.section {
+  padding-top: 30px;
+  padding-bottom: 50px;
+}
+
+.subtitle {
+  color: #5f6973;
+  font-size: 15px;
+  margin-top: 8px;
+}
+
+.badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  background: #1a3760;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 5px 11px;
+  border-radius: 999px;
+}
+
+.cardSubtitle {
+  color: #5f6973;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.ends {
+  color: #888888;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 16px;
+}

--- a/app/components/pages/promotions/PromotionsStickyCTA.js
+++ b/app/components/pages/promotions/PromotionsStickyCTA.js
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslations } from "next-intl";
-import { MAPS_URL } from "./promoUtils";
+import { BUSINESS_MAPS_URL } from "./promoUtils";
 import styles from "./Promotions.module.css";
 
 function PinIcon() {
@@ -17,7 +17,7 @@ export default function PromotionsStickyCTA() {
   return (
     <div className={styles.stickyBar}>
       <a
-        href={MAPS_URL}
+        href={BUSINESS_MAPS_URL}
         target="_blank"
         rel="noopener noreferrer"
         className={styles.stickyBtn}

--- a/app/components/pages/promotions/promoUtils.js
+++ b/app/components/pages/promotions/promoUtils.js
@@ -1,5 +1,9 @@
 export const WHATSAPP_PHONE = "60127126128";
 export const MAPS_URL = "https://maps.app.goo.gl/a9Fs6RkRSR8dnnsE9";
+// Opens Google Maps on the "Perniagaan Motor Kekal" business listing
+// (searches by business name rather than a raw address).
+export const BUSINESS_MAPS_URL =
+  "https://www.google.com/maps/search/?api=1&query=Perniagaan+Motor+Kekal";
 
 export function whatsappLink(promotion) {
   const text =

--- a/messages/en.json
+++ b/messages/en.json
@@ -48,7 +48,10 @@
   "home": {
     "featuredListings": "Featured Listings",
     "showAllMotorcycles": "Show All Motorcycles",
-    "ourTestimonials": "Our Testimonials"
+    "ourTestimonials": "Our Testimonials",
+    "promotionsHeading": "Current Promotions",
+    "promotionsSubtitle": "Limited-time deals — claim them while they last",
+    "viewAllPromotions": "View All Promotions"
   },
   "testimonials": {
     "rider1Role": "Professional Rider",
@@ -394,6 +397,6 @@
     "offerEnds": "Offer ends {date}",
     "endedOn": "Ended {date}",
     "claimDeal": "Claim this deal",
-    "visitToClaim": "Visit us to claim · Johor Jaya"
+    "visitToClaim": "Visit Us"
   }
 }

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -48,7 +48,10 @@
   "home": {
     "featuredListings": "Senarai Pilihan",
     "showAllMotorcycles": "Lihat Semua Motosikal",
-    "ourTestimonials": "Testimoni Kami"
+    "ourTestimonials": "Testimoni Kami",
+    "promotionsHeading": "Promosi Terkini",
+    "promotionsSubtitle": "Tawaran masa terhad — claim sebelum tamat",
+    "viewAllPromotions": "Lihat Semua Promosi"
   },
   "testimonials": {
     "rider1Role": "Penunggang Profesional",
@@ -394,6 +397,6 @@
     "offerEnds": "Tawaran tamat {date}",
     "endedOn": "Tamat {date}",
     "claimDeal": "Claim tawaran ini",
-    "visitToClaim": "Datang untuk claim · Johor Jaya"
+    "visitToClaim": "Lawati Kami"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -48,7 +48,10 @@
   "home": {
     "featuredListings": "精选车辆",
     "showAllMotorcycles": "查看所有摩托车",
-    "ourTestimonials": "客户评价"
+    "ourTestimonials": "客户评价",
+    "promotionsHeading": "最新优惠",
+    "promotionsSubtitle": "限时优惠 — 把握机会，先到先得",
+    "viewAllPromotions": "查看所有优惠"
   },
   "testimonials": {
     "rider1Role": "专业骑士",
@@ -394,6 +397,6 @@
     "offerEnds": "优惠截止 {date}",
     "endedOn": "已于 {date} 结束",
     "claimDeal": "领取优惠",
-    "visitToClaim": "到店领取 · Johor Jaya"
+    "visitToClaim": "到店参观"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "firebase": "^10.1.0",
     "firebase-admin": "^11.11.0",
     "html2canvas": "^1.4.1",
+    "jose": "^6.2.3",
     "jspdf": "^3.0.3",
     "next": "13.4.5",
     "next-intl": "^3",

--- a/utils/firebaseAdmin.js
+++ b/utils/firebaseAdmin.js
@@ -1,30 +1,27 @@
-import { initializeApp, getApps, cert } from "firebase-admin/app";
-import { getAuth } from "firebase-admin/auth";
-import { getFirestore } from "firebase-admin/firestore";
 import { NextResponse } from "next/server";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/utils/firebase";
 
-let adminAuth;
-let adminDb;
+// Firebase ID tokens are standard RS256 JWTs signed by Google. We can verify
+// them with Google's *public* keys — no service-account private key required.
+// The private key is only needed to mint tokens / do privileged Admin writes,
+// neither of which we do here.
+const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 
-function getAdminServices() {
-  if (adminAuth) return { adminAuth, adminDb };
+// Google's public signing keys for Firebase ID tokens. createRemoteJWKSet
+// fetches once and caches, refreshing automatically on key rotation.
+const JWKS = createRemoteJWKSet(
+  new URL(
+    "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
+  )
+);
 
-  const app =
-    getApps().length > 0
-      ? getApps()[0]
-      : initializeApp({
-          credential: cert(
-            JSON.parse(
-              process.env.FIREBASE_SERVICE_ACCOUNT
-                .replace(/\\n/g, "\n")
-                .replace(/\\"/g, '"')
-            )
-          ),
-        });
-
-  adminAuth = getAuth(app);
-  adminDb = getFirestore(app);
-  return { adminAuth, adminDb };
+// Same allowlist the client login flow reads (config/emailConfig in Firestore),
+// fetched here with the client SDK — no Admin SDK needed.
+async function getAuthorizedEmails() {
+  const snap = await getDoc(doc(db, "config", "emailConfig"));
+  return snap.exists() ? snap.data().authorizedReceiptEmails || [] : [];
 }
 
 export async function verifyAuthToken(request) {
@@ -38,26 +35,15 @@ export async function verifyAuthToken(request) {
     };
   }
 
+  const token = authHeader.split("Bearer ")[1];
+
+  let decoded;
   try {
-    const token = authHeader.split("Bearer ")[1];
-    const { adminAuth, adminDb } = getAdminServices();
-    const decoded = await adminAuth.verifyIdToken(token);
-
-    const doc = await adminDb.collection("config").doc("emailConfig").get();
-    const authorizedEmails = doc.exists
-      ? doc.data().authorizedReceiptEmails || []
-      : [];
-
-    if (!authorizedEmails.includes(decoded.email)) {
-      return {
-        error: NextResponse.json(
-          { error: "Unauthorized" },
-          { status: 403 }
-        ),
-      };
-    }
-
-    return { decoded };
+    const { payload } = await jwtVerify(token, JWKS, {
+      issuer: `https://securetoken.google.com/${projectId}`,
+      audience: projectId,
+    });
+    decoded = payload;
   } catch {
     return {
       error: NextResponse.json(
@@ -66,4 +52,23 @@ export async function verifyAuthToken(request) {
       ),
     };
   }
+
+  try {
+    const authorizedEmails = await getAuthorizedEmails();
+    if (!decoded.email || !authorizedEmails.includes(decoded.email)) {
+      return {
+        error: NextResponse.json({ error: "Unauthorized" }, { status: 403 }),
+      };
+    }
+  } catch (error) {
+    console.error("Failed to load authorized emails:", error);
+    return {
+      error: NextResponse.json(
+        { error: "Failed to verify authorization" },
+        { status: 500 }
+      ),
+    };
+  }
+
+  return { decoded };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7425,6 +7425,11 @@ jose@^4.14.6:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
   integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
 
+jose@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
+  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"


### PR DESCRIPTION
## Summary
A set of promotions-focused improvements plus a fix for the admin panel 401s.

### Home page
- New **Featured Promotions** section on `/` (and `/[locale]/home`), styled to match the home design (`.car-listing` cards, navy uppercase titles, gold CTA, `main-title` heading, "View All Promotions" link).
- Client-fetched (same pattern as the existing Featured Listings) so the home page stays statically rendered.
- Renders **nothing** when no promotion is featured.

### Promotions page (`/promotions`)
- Renders **all** featured promos as hero cards (previously only the first).
- **No fallback**: when nothing is featured, no hero is shown (non-featured live promos still appear under "More offers").

### Admin
- Clicking a promotion **row** opens its edit page; Delete/Edit buttons keep working (click no longer bubbles to the row).

### "Visit Us" CTA
- The promotions sticky button now reads **"Visit Us"** and links to the **Google Business listing** (search by business name) instead of a raw address. Translated for en/ms/zh.

### Admin auth fix (the important one)
- Root cause of the admin **401s**: `FIREBASE_SERVICE_ACCOUNT` was never set, so `firebase-admin` couldn't initialize and every token verification failed.
- Reworked `verifyAuthToken` to verify Firebase ID tokens against **Google's public keys** (`jose`) + the **existing Firestore allowlist** (`config/emailConfig`, read with the client SDK). **No private key / `FIREBASE_SERVICE_ACCOUNT` needed.**
- Same mechanism your login flow already uses for the allowlist.

## Notes / follow-ups
- Home & promotions cards are client-fetched, so not in the initial SSR HTML (consistent with the existing Featured Listings). The `/promotions` page still carries SEO schema. Server-rendering these on the homepage is a possible follow-up.
- `firebase-admin` is left installed (still used by the `scrape-motorcycles.mjs` script); the web app no longer depends on it. After deploy you can remove `FIREBASE_SERVICE_ACCOUNT` from Vercel if it was ever set (keep `NEXT_PUBLIC_FIREBASE_PROJECT_ID`).

## Verification
- ESLint clean (lint-staged ran on commit).
- Verified in-browser: zero-featured (no hero), multiple-featured (stacked heroes), home section with 2 featured promos, and "Visit Us" href.
- Auth: missing/invalid token → clean 401 (no crash); public GET → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)