### PR TITLE
feat(storefront): redesigned 404 page with quick links + not-found boundary

### DIFF
--- a/app/[locale]/[...not_found]/page.js
+++ b/app/[locale]/[...not_found]/page.js
@@ -1,58 +1,18 @@
-import SiteHeader from "@/app/components/motorkekal/SiteHeader";
-import SiteFooter from "@/app/components/motorkekal/SiteFooter";
-import MobileBar from "@/app/components/motorkekal/MobileBar";
-import { Link } from "@/i18n/navigation";
+import NotFoundContent from "@/app/components/motorkekal/NotFoundContent";
 import { setRequestLocale } from "next-intl/server";
-import { useTranslations } from "next-intl";
 
 export const metadata = {
   title: "Page Not Found - Perniagaan Motor Kekal",
   description: "The page you are looking for could not be found.",
   robots: {
     index: false,
-    follow: false,
+    follow: true,
   },
 };
 
 const NotFound = ({ params: { locale } }) => {
   setRequestLocale(locale);
-  const t = useTranslations("notFound");
-  return (
-    <div className="wrapper" style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
-      <SiteHeader />
-
-      <section className="our-error bgc-f9" style={{ flex: 1 }}>
-        <div className="container">
-          <div className="row">
-            <div className="col-xl-6 offset-xl-3 text-center">
-              <div className="error_page">
-                <div className="erro_code">
-                  <h2>
-                    4<span className="text-thm">0</span>4
-                  </h2>
-                </div>
-                <h3
-                  className="subtitle"
-                  style={{ marginBottom: "12px", fontWeight: 700 }}
-                >
-                  {t("title")}
-                </h3>
-                <p style={{ color: "#5f6973", marginBottom: "35px" }}>
-                  {t("description")}
-                </p>
-              </div>
-              <Link className="btn_error" href="/">
-                {t("backHome")}
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <SiteFooter />
-      <MobileBar />
-    </div>
-  );
+  return <NotFoundContent />;
 };
 
 export default NotFound;

--- a/app/[locale]/not-found.js
+++ b/app/[locale]/not-found.js
@@ -1,0 +1,7 @@
+import NotFoundContent from "@/app/components/motorkekal/NotFoundContent";
+
+// Boundary for programmatic notFound() calls (e.g. an invalid motorcycle
+// slug). Unknown URLs are handled by the [...not_found] catch-all instead.
+const NotFound = () => <NotFoundContent />;
+
+export default NotFound;

--- a/app/components/motorkekal/NotFoundContent.js
+++ b/app/components/motorkekal/NotFoundContent.js
@@ -1,0 +1,112 @@
+import SiteHeader from "@/app/components/motorkekal/SiteHeader";
+import SiteFooter from "@/app/components/motorkekal/SiteFooter";
+import MobileBar from "@/app/components/motorkekal/MobileBar";
+import { waLink, WaIcon } from "@/app/components/motorkekal/waLink";
+import { Link } from "@/i18n/navigation";
+import { useTranslations } from "next-intl";
+
+const BikeIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="6.5" cy="17" r="3" />
+    <circle cx="17.5" cy="17" r="3" />
+    <path
+      d="M6.5 17l3-8h4l4 8M9.5 9l-2-3h-3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const TagIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path
+      d="M20.6 13.4l-7.2 7.2a2 2 0 01-2.8 0L3 13V3h10l7.6 7.6a2 2 0 010 2.8z"
+      strokeLinejoin="round"
+    />
+    <circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+const WrenchIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path
+      d="M14.7 6.3a5 5 0 00-7 7l1 1 6-6zM9 17l6-6 4 4a3 3 0 01-4 4z"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const WA_MESSAGE =
+  "Hi Motor Kekal, saya cari sesuatu di website tapi tak jumpa. Boleh tolong?";
+
+// Shared 404 UI, rendered both by the [...not_found] catch-all route and by
+// the not-found.js boundary that catches programmatic notFound() calls.
+const NotFoundContent = () => {
+  const t = useTranslations("notFound");
+
+  const quickLinks = [
+    { href: "/listing", icon: <BikeIcon />, title: t("linkBikes"), sub: t("linkBikesSub") },
+    { href: "/promotions", icon: <TagIcon />, title: t("linkPromos"), sub: t("linkPromosSub") },
+    { href: "/service", icon: <WrenchIcon />, title: t("linkServices"), sub: t("linkServicesSub") },
+  ];
+
+  return (
+    <div className="mk-site">
+      <SiteHeader />
+
+      <main>
+        <section className="nf wrap">
+          <div className="nf__grid">
+            <div>
+              <div className="nf__code">
+                4<em>0</em>4
+              </div>
+              <div className="nf__skid"></div>
+              <p className="muted" style={{ marginTop: 22, fontSize: 14 }}>
+                {t("caption")}
+              </p>
+            </div>
+            <div>
+              <p className="eyebrow">{t("eyebrow")}</p>
+              <h1>{t("title")}</h1>
+              <p className="nf__sub">{t("description")}</p>
+
+              <div className="nf__links">
+                {quickLinks.map((link) => (
+                  <Link className="nf__link" href={link.href} key={link.href}>
+                    <span className="svc-card__ico">{link.icon}</span>
+                    <span>
+                      <b>{link.title}</b>
+                      <span>{link.sub}</span>
+                    </span>
+                    <span className="nf__arrow">→</span>
+                  </Link>
+                ))}
+              </div>
+
+              <div className="nf__cta">
+                <Link className="btn btn--ink" href="/">
+                  ← {t("backHome")}
+                </Link>
+                <a
+                  className="btn btn--wa"
+                  href={waLink(WA_MESSAGE)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <WaIcon />
+                  {t("askUs")}
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+      <MobileBar waMessage={WA_MESSAGE} />
+    </div>
+  );
+};
+
+export default NotFoundContent;

--- a/app/components/motorkekal/motorkekal.css
+++ b/app/components/motorkekal/motorkekal.css
@@ -1652,3 +1652,127 @@
     padding: 24px;
   }
 }
+
+/* ------------------------------------------------------------------
+   404 / not-found page
+------------------------------------------------------------------ */
+.mk-site .nf {
+  min-height: calc(100vh - 68px - 90px);
+  display: flex;
+  align-items: center;
+}
+.mk-site .nf__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: center;
+  width: 100%;
+}
+.mk-site .nf__code {
+  font-size: clamp(90px, 14vw, 170px);
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+  color: var(--kk-ink);
+}
+.mk-site .nf__code em {
+  color: var(--kk-orange);
+  font-style: normal;
+}
+.mk-site .nf__skid {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--kk-orange);
+  width: 62%;
+  margin-top: 26px;
+  position: relative;
+}
+.mk-site .nf__skid::after {
+  content: "";
+  position: absolute;
+  left: calc(100% + 12px);
+  top: 0;
+  width: 34px;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--kk-orange);
+  opacity: 0.45;
+}
+.mk-site .nf__skid::before {
+  content: "";
+  position: absolute;
+  left: calc(100% + 58px);
+  top: 0;
+  width: 14px;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--kk-orange);
+  opacity: 0.22;
+}
+.mk-site .nf h1 {
+  font-size: clamp(26px, 3.4vw, 38px);
+}
+.mk-site .nf__sub {
+  color: var(--kk-text-muted);
+  font-size: 17px;
+  margin-top: 14px;
+  max-width: 34em;
+}
+.mk-site .nf__links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 28px;
+}
+.mk-site .nf__link {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  background: var(--kk-card);
+  border: 1px solid var(--kk-border);
+  border-radius: 14px;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+.mk-site .nf__link:hover {
+  border-color: var(--kk-border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px -26px rgba(23, 24, 28, 0.5);
+}
+.mk-site .nf__link .svc-card__ico {
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+}
+.mk-site .nf__link .svc-card__ico svg {
+  width: 21px;
+  height: 21px;
+}
+.mk-site .nf__link b {
+  font-size: 15px;
+  display: block;
+}
+.mk-site .nf__link span {
+  font-size: 13px;
+  color: var(--kk-text-muted);
+}
+.mk-site .nf__link .nf__arrow {
+  margin-left: auto;
+  color: var(--kk-text-muted);
+}
+.mk-site .nf__cta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+@media (max-width: 860px) {
+  .mk-site .nf {
+    min-height: 0;
+    padding-block: 40px 10px;
+  }
+  .mk-site .nf__grid {
+    grid-template-columns: 1fr;
+    gap: 34px;
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -348,9 +348,18 @@
     ]
   },
   "notFound": {
-    "title": "Page Not Found",
-    "description": "The page you are looking for might have been removed or is temporarily unavailable.",
-    "backHome": "Back to Home"
+    "eyebrow": "Page not found",
+    "title": "Whoops - dead end.",
+    "description": "The page you're looking for has moved or doesn't exist. Don't worry — the bike you're after might still be here.",
+    "caption": "This page changed lanes.",
+    "linkBikes": "Browse all motorcycles",
+    "linkBikesSub": "Y15ZR, RS150R, NMAX, PCX160 & more",
+    "linkPromos": "This month's promotions",
+    "linkPromosSub": "Cash rebates, low deposit, free gifts",
+    "linkServices": "Services",
+    "linkServicesSub": "Financing, trade-in, warranty & insurance",
+    "backHome": "Back to home",
+    "askUs": "Ask us directly"
   },
   "listing": {
     "breadcrumbTitle": "Motorcycles For Sale",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -348,9 +348,18 @@
     ]
   },
   "notFound": {
-    "title": "Halaman Tidak Dijumpai",
-    "description": "Halaman yang anda cari mungkin telah dialih keluar atau tidak tersedia buat sementara waktu.",
-    "backHome": "Kembali ke Laman Utama"
+    "eyebrow": "Halaman tidak dijumpai",
+    "title": "Alamak - jalan mati.",
+    "description": "Halaman yang anda cari dah dipindahkan atau tak wujud. Tapi jangan risau — motor yang anda cari mungkin masih ada.",
+    "caption": "Halaman ini dah tukar lorong.",
+    "linkBikes": "Lihat semua motosikal",
+    "linkBikesSub": "Y15ZR, RS150R, NMAX, PCX160 & lagi",
+    "linkPromos": "Promosi bulan ini",
+    "linkPromosSub": "Rebat tunai, deposit rendah, hadiah percuma",
+    "linkServices": "Perkhidmatan",
+    "linkServicesSub": "Pembiayaan, tukar-beli, waranti & insurans",
+    "backHome": "Balik ke laman utama",
+    "askUs": "Tanya kami terus"
   },
   "listing": {
     "breadcrumbTitle": "Motosikal Untuk Dijual",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -348,9 +348,18 @@
     ]
   },
   "notFound": {
-    "title": "找不到页面",
-    "description": "您所查找的页面可能已被移除或暂时无法使用。",
-    "backHome": "返回首页"
+    "eyebrow": "找不到页面",
+    "title": "哎呀，此路不通。",
+    "description": "您要找的页面已被移动或不存在。别担心——您想找的摩托车可能还在。",
+    "caption": "这个页面换车道了。",
+    "linkBikes": "查看所有摩托车",
+    "linkBikesSub": "Y15ZR、RS150R、NMAX、PCX160 等",
+    "linkPromos": "本月促销",
+    "linkPromosSub": "现金回扣、低首付、免费礼品",
+    "linkServices": "服务项目",
+    "linkServicesSub": "贷款、以旧换新、保修与保险",
+    "backHome": "返回主页",
+    "askUs": "直接问我们"
   },
   "listing": {
     "breadcrumbTitle": "待售摩托车",


### PR DESCRIPTION
## Summary
- Port the 404 page design from Claude Design into the `.mk-site` design system: skid-mark 404 hero, quick-link cards (motorcycles / promotions / services), and home + WhatsApp CTAs
- Localize the new copy in English, Malay, and Chinese (`notFound` block in all three message files)
- Extract the UI into a shared `NotFoundContent` component used by both 404 entry points
- **Fix:** add `app/[locale]/not-found.js` boundary — programmatic `notFound()` calls (e.g. an invalid motorcycle slug like `/motorcycle/fake-bike-abc123`) previously crashed with an unhandled `NEXT_NOT_FOUND` runtime error; they now render the same 404 page

## How the 404 is triggered
1. **Unknown URLs** → matched by the `app/[locale]/[...not_found]` catch-all route (next-intl localized-404 pattern)
2. **`notFound()` calls** → caught by the new `app/[locale]/not-found.js` boundary

## Testing
- Verified with Playwright against the dev server: desktop 1280×800 (en + ms) and mobile 390×844, including CTA clearance above the sticky Call/WhatsApp bar
- Verified the invalid-slug path now returns a proper HTTP 404 with the new page instead of crashing
- `yarn lint` passes (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)