### PR TITLE
feat(seo): contact page, per-locale canonicals/hreflang, real 404s

### DIFF
--- a/app/[locale]/(listing)/(listing-styles)/listing/layout.js
+++ b/app/[locale]/(listing)/(listing-styles)/listing/layout.js
@@ -1,32 +1,33 @@
 import ItemListSchema from "@/app/components/seo/ItemListSchema";
+import { localeAlternates } from "@/utils/seoAlternates";
 
-export const metadata = {
-  title: "Jual Motor Baru Johor Bahru - Yamaha, Kawasaki, Honda, KTM",
-  description:
-    "Senarai motor baru untuk dijual di Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & lain-lain. Harga motor murah, loan kedai tersedia. Kedai motor JB.",
-  keywords: [
-    "kedai jual motor johor bahru",
-    "kedai jual motor near me",
-    "motor murah johor",
-    "yamaha johor jaya",
-    "kedai motor johor bahru",
-    "motorcycle shop johor bahru",
-    "motor loan kedai jb",
-    "beli motor johor bahru",
-    "kedai motor yamaha near me",
-    "best motorcycle shop in jb",
-  ],
-  alternates: {
-    canonical: "/listing",
-  },
-  openGraph: {
-    title: "Jual Motor Baru - Perniagaan Motor Kekal, Johor Bahru",
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "Jual Motor Baru Johor Bahru - Yamaha, Kawasaki, Honda, KTM",
     description:
-      "Senarai motor baru Yamaha, Kawasaki, Honda, KTM. Harga terbaik di Johor Bahru. Loan kedai tersedia.",
-    url: "https://www.motorkekal.com/listing",
-    type: "website",
-  },
-};
+      "Senarai motor baru untuk dijual di Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & lain-lain. Harga motor murah, loan kedai tersedia. Kedai motor JB.",
+    keywords: [
+      "kedai jual motor johor bahru",
+      "kedai jual motor near me",
+      "motor murah johor",
+      "yamaha johor jaya",
+      "kedai motor johor bahru",
+      "motorcycle shop johor bahru",
+      "motor loan kedai jb",
+      "beli motor johor bahru",
+      "kedai motor yamaha near me",
+      "best motorcycle shop in jb",
+    ],
+    alternates: localeAlternates("/listing", locale),
+    openGraph: {
+      title: "Jual Motor Baru - Perniagaan Motor Kekal, Johor Bahru",
+      description:
+        "Senarai motor baru Yamaha, Kawasaki, Honda, KTM. Harga terbaik di Johor Bahru. Loan kedai tersedia.",
+      url: "https://www.motorkekal.com/listing",
+      type: "website",
+    },
+  };
+}
 
 export default async function ListingLayout({ children }) {
   return (

--- a/app/[locale]/(pages)/about-us/page.js
+++ b/app/[locale]/(pages)/about-us/page.js
@@ -6,20 +6,23 @@ import SiteFooter from "@/app/components/motorkekal/SiteFooter";
 import MobileBar from "@/app/components/motorkekal/MobileBar";
 import Map from "@/app/components/common/Map";
 import { waLink, MAPS_QUERY_URL, ADDRESS, PHONE_DISPLAY } from "@/app/components/motorkekal/waLink";
+import { localeAlternates } from "@/utils/seoAlternates";
 
-export const metadata = {
-  title: "Tentang Kami - Kedai Motor Johor Bahru | Perniagaan Motor Kekal",
-  description:
-    "Perniagaan Motor Kekal, kedai motor keluarga di Johor Bahru sejak lebih 30 tahun. Pengedar Yamaha, Kawasaki, Honda, KTM — jujur, mesra dan dipercayai orang JB.",
-  keywords: [
-    "perniagaan motor kekal",
-    "tentang motor kekal",
-    "kedai motor johor bahru",
-    "kedai motor near me",
-    "pengedar motosikal jb",
-  ],
-  alternates: { canonical: "/about-us" },
-};
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "Tentang Kami - Kedai Motor Johor Bahru | Perniagaan Motor Kekal",
+    description:
+      "Perniagaan Motor Kekal, kedai motor keluarga di Johor Bahru sejak lebih 30 tahun. Pengedar Yamaha, Kawasaki, Honda, KTM — jujur, mesra dan dipercayai orang JB.",
+    keywords: [
+      "perniagaan motor kekal",
+      "tentang motor kekal",
+      "kedai motor johor bahru",
+      "kedai motor near me",
+      "pengedar motosikal jb",
+    ],
+    alternates: localeAlternates("/about-us", locale),
+  };
+}
 
 const BANNER_IMG =
   "https://images.unsplash.com/photo-1694274855681-1b12cd585066?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1400";

--- a/app/[locale]/(pages)/contact/page.js
+++ b/app/[locale]/(pages)/contact/page.js
@@ -1,0 +1,207 @@
+import { setRequestLocale } from "next-intl/server";
+import { useTranslations } from "next-intl";
+import SiteHeader from "@/app/components/motorkekal/SiteHeader";
+import SiteFooter from "@/app/components/motorkekal/SiteFooter";
+import MobileBar from "@/app/components/motorkekal/MobileBar";
+import Map from "@/app/components/common/Map";
+import {
+  waLink,
+  MAPS_QUERY_URL,
+  ADDRESS,
+  PHONE,
+  PHONE_DISPLAY,
+} from "@/app/components/motorkekal/waLink";
+import { localeAlternates } from "@/utils/seoAlternates";
+
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "Hubungi Kami - Kedai Motor Johor Jaya, JB",
+    description:
+      "Hubungi Perniagaan Motor Kekal: telefon, WhatsApp atau datang terus ke kedai kami di Taman Johor Bahru (Johor Jaya). Buka setiap hari 9 pagi - 7 malam, Jumaat tutup.",
+    keywords: [
+      "kedai motor johor jaya",
+      "kedai motor johor bahru contact",
+      "kedai motor near me",
+      "motor kekal contact",
+      "whatsapp kedai motor jb",
+    ],
+    alternates: localeAlternates("/contact", locale),
+  };
+}
+
+const CARD_ICONS = {
+  phone: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M5 4h4l2 5-3 2a12 12 0 005 5l2-3 5 2v4a2 2 0 01-2 2A16 16 0 013 6a2 2 0 012-2z" />
+    </svg>
+  ),
+  wa: (
+    <svg viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2a10 10 0 00-8.6 15l-1.4 5 5.1-1.3A10 10 0 1012 2zm0 18.3c-1.5 0-3-.4-4.3-1.1l-.3-.2-3 .8.8-3-.2-.3A8.3 8.3 0 1112 20.3z" />
+    </svg>
+  ),
+  pin: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 21s-7-6.3-7-11a7 7 0 1114 0c0 4.7-7 11-7 11z" />
+      <circle cx="12" cy="10" r="2.5" />
+    </svg>
+  ),
+  clock: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" strokeLinecap="round" />
+    </svg>
+  ),
+};
+
+const Contact = ({ params: { locale } }) => {
+  setRequestLocale(locale);
+  const t = useTranslations("mk.contact");
+  const tAbout = useTranslations("mk.about");
+
+  return (
+    <div className="mk-site">
+      <SiteHeader />
+
+      <main>
+        <div className="wrap">
+          <nav className="crumbs" aria-label="Breadcrumb">
+            <a href="/">{tAbout("crumbHome")}</a>
+            <span>›</span>
+            {t("crumbCurrent")}
+          </nav>
+        </div>
+
+        <section className="page-hero wrap">
+          <p className="eyebrow">{t("eyebrow")}</p>
+          <h1>{t("heading")}</h1>
+          <p>{t("sub")}</p>
+        </section>
+
+        {/* Contact channels */}
+        <section className="section--tight wrap">
+          <div className="svc-grid">
+            <article className="card card--hover svc-card">
+              <div className="svc-card__ico">{CARD_ICONS.phone}</div>
+              <div>
+                <h3>{t("callTitle")}</h3>
+                <p>{t("callDesc")}</p>
+                <a className="btn btn--outline" href={`tel:+${PHONE}`} style={{ marginTop: 12 }}>
+                  {PHONE_DISPLAY}
+                </a>
+              </div>
+            </article>
+            <article className="card card--hover svc-card">
+              <div className="svc-card__ico">{CARD_ICONS.wa}</div>
+              <div>
+                <h3>{t("waTitle")}</h3>
+                <p>{t("waDesc")}</p>
+                <a
+                  className="btn btn--wa"
+                  href={waLink(t("waPrefill"))}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ marginTop: 12 }}
+                >
+                  {t("waCta")}
+                </a>
+              </div>
+            </article>
+            <article className="card card--hover svc-card">
+              <div className="svc-card__ico">{CARD_ICONS.pin}</div>
+              <div>
+                <h3>{t("visitTitle")}</h3>
+                <p>
+                  {ADDRESS}
+                  <br />
+                  {t("visitDesc")}
+                </p>
+                <a
+                  className="btn btn--outline"
+                  href={MAPS_QUERY_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ marginTop: 12 }}
+                >
+                  {t("visitCta")}
+                </a>
+              </div>
+            </article>
+            <article className="card card--hover svc-card">
+              <div className="svc-card__ico">{CARD_ICONS.clock}</div>
+              <div>
+                <h3>{t("hoursTitle")}</h3>
+                <p>
+                  {t("hoursValue")}
+                  <br />
+                  {t("hoursNote")}
+                </p>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        {/* Location / NAP */}
+        <section className="section--tight wrap">
+          <div className="local">
+            <div className="local__map">
+              <Map />
+            </div>
+            <div className="local__info">
+              <p className="eyebrow" style={{ color: "#fff", opacity: 0.7 }}>
+                {t("findEyebrow")}
+              </p>
+              <h2>{t("findHeading")}</h2>
+              <div className="nap">
+                <div className="nap__row">
+                  {CARD_ICONS.pin}
+                  <div>
+                    <b>Perniagaan Motor Kekal</b>
+                    {ADDRESS}
+                  </div>
+                </div>
+                <div className="nap__row">
+                  {CARD_ICONS.phone}
+                  <div>
+                    <b>{PHONE_DISPLAY}</b>
+                    WhatsApp &amp; {tAbout("phoneNote")}
+                  </div>
+                </div>
+                <div className="nap__row">
+                  {CARD_ICONS.clock}
+                  <div>
+                    <b>{tAbout("hoursLabel")}</b>
+                    {t("hoursValue")}
+                  </div>
+                </div>
+              </div>
+              <div style={{ display: "flex", gap: 10, marginTop: 26, flexWrap: "wrap" }}>
+                <a
+                  className="btn btn--primary"
+                  href={MAPS_QUERY_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t("visitCta")}
+                </a>
+                <a
+                  className="btn btn--wa"
+                  href={waLink(t("waPrefill"))}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {tAbout("whatsappUs")}
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+      <MobileBar waMessage="Hi Motor Kekal, saya nak tanya pasal kedai." />
+    </div>
+  );
+};
+
+export default Contact;

--- a/app/[locale]/(pages)/promotions/page.js
+++ b/app/[locale]/(pages)/promotions/page.js
@@ -7,25 +7,26 @@ import PromotionSchema from "@/app/components/seo/PromotionSchema";
 import { waLink, WaIcon } from "@/app/components/motorkekal/waLink";
 import { listLivePromotionsPg, listPastPromotionsPg } from "@/utils/dbPg";
 import { setRequestLocale, getTranslations } from "next-intl/server";
+import { localeAlternates } from "@/utils/seoAlternates";
 
 // Promotions are time-sensitive; always render the current live set.
 export const dynamic = "force-dynamic";
 
-export const metadata = {
-  title: "Promosi Motor Johor Bahru - Tawaran & Diskaun Kekal Motor",
-  description:
-    "Tawaran terhad motor baru, servis & trade-in di Johor Jaya, JB. Lihat promosi terkini Kekal Motor dengan kira detik — datang showroom untuk claim.",
-  keywords: [
-    "promosi motor johor bahru",
-    "tawaran motor johor jaya",
-    "diskaun motor yamaha",
-    "promosi motor baru",
-    "motorcycle promotion johor bahru",
-  ],
-  alternates: {
-    canonical: "/promotions",
-  },
-};
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "Promosi Motor Johor Bahru - Tawaran & Diskaun Kekal Motor",
+    description:
+      "Tawaran terhad motor baru, servis & trade-in di Johor Jaya, JB. Lihat promosi terkini Kekal Motor dengan kira detik — datang showroom untuk claim.",
+    keywords: [
+      "promosi motor johor bahru",
+      "tawaran motor johor jaya",
+      "diskaun motor yamaha",
+      "promosi motor baru",
+      "motorcycle promotion johor bahru",
+    ],
+    alternates: localeAlternates("/promotions", locale),
+  };
+}
 
 const Promotions = async ({ params: { locale } }) => {
   setRequestLocale(locale);

--- a/app/[locale]/(pages)/service/page.js
+++ b/app/[locale]/(pages)/service/page.js
@@ -6,21 +6,24 @@ import SiteFooter from "@/app/components/motorkekal/SiteFooter";
 import MobileBar from "@/app/components/motorkekal/MobileBar";
 import Pill from "@/app/components/motorkekal/Pill";
 import { waLink } from "@/app/components/motorkekal/waLink";
+import { localeAlternates } from "@/utils/seoAlternates";
 
-export const metadata = {
-  title: "Servis Motor Johor Bahru - Yamaha, Kawasaki Service Center",
-  description:
-    "Pusat servis motor di Johor Bahru. Pembiayaan mudah lulus, tukar-beli, waranti & servis bengkel sendiri, insurans & renew cukai jalan. Semua bawah satu bumbung.",
-  keywords: [
-    "pembiayaan motosikal johor bahru",
-    "loan motor mudah lulus",
-    "trade-in motor johor bahru",
-    "servis motor johor bahru",
-    "insurans motor",
-    "renew cukai jalan johor",
-  ],
-  alternates: { canonical: "/service" },
-};
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "Servis Motor Johor Bahru - Yamaha, Kawasaki Service Center",
+    description:
+      "Pusat servis motor di Johor Bahru. Pembiayaan mudah lulus, tukar-beli, waranti & servis bengkel sendiri, insurans & renew cukai jalan. Semua bawah satu bumbung.",
+    keywords: [
+      "pembiayaan motosikal johor bahru",
+      "loan motor mudah lulus",
+      "trade-in motor johor bahru",
+      "servis motor johor bahru",
+      "insurans motor",
+      "renew cukai jalan johor",
+    ],
+    alternates: localeAlternates("/service", locale),
+  };
+}
 
 const IMG_A =
   "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=1080";

--- a/app/[locale]/[...not_found]/page.js
+++ b/app/[locale]/[...not_found]/page.js
@@ -1,8 +1,9 @@
-import NotFoundContent from "@/app/components/motorkekal/NotFoundContent";
+import { notFound } from "next/navigation";
 import { setRequestLocale } from "next-intl/server";
 
 export const metadata = {
-  title: "Page Not Found - Perniagaan Motor Kekal",
+  // Brand is appended by the layout title template.
+  title: "Page Not Found",
   description: "The page you are looking for could not be found.",
   robots: {
     index: false,
@@ -10,9 +11,12 @@ export const metadata = {
   },
 };
 
+// Throw notFound() so the not-found.js boundary renders with a real HTTP 404
+// status. Rendering the 404 UI directly here returned 200, which Google
+// treats as a soft 404 and keeps recrawling.
 const NotFound = ({ params: { locale } }) => {
   setRequestLocale(locale);
-  return <NotFoundContent />;
+  notFound();
 };
 
 export default NotFound;

--- a/app/[locale]/faq/FAQContent.js
+++ b/app/[locale]/faq/FAQContent.js
@@ -1,0 +1,128 @@
+"use client";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import SiteHeader from "@/app/components/motorkekal/SiteHeader";
+import SiteFooter from "@/app/components/motorkekal/SiteFooter";
+import MobileBar from "@/app/components/motorkekal/MobileBar";
+import styles from "./faq.module.css";
+
+// Category ids map to message-catalog keys (data arrays + display label).
+const CATEGORY_IDS = ["financing", "delivery", "warranty"];
+const CATEGORY_LABEL_KEYS = {
+  financing: "categories.Financing",
+  delivery: "categories.Delivery",
+  warranty: "categories.Warranty",
+};
+
+export default function FAQContent() {
+  const t = useTranslations("faq");
+  const [activeCategory, setActiveCategory] = useState(CATEGORY_IDS[0]);
+  const [openIndex, setOpenIndex] = useState(0);
+
+  // Pull localized question/answer arrays from the message catalog.
+  const faqData = CATEGORY_IDS.reduce((acc, id) => {
+    acc[id] = t.raw(id);
+    return acc;
+  }, {});
+
+  const questions = faqData[activeCategory];
+
+  const faqSchemaData = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: CATEGORY_IDS.flatMap((id) => faqData[id]).map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+
+  return (
+    <div className="wrapper">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchemaData) }}
+      />
+      <SiteHeader />
+
+      <section className={styles.faqSection}>
+        <div className="container">
+          <div className="row justify-content-center">
+            <div className="col-lg-8 col-xl-7">
+              <div className={styles.content}>
+                <h1 className={styles.heading}>
+                  {t("heading")}<br />{t("headingLine2")}
+                </h1>
+                <p className={styles.subtext}>{t("subtext")}</p>
+
+                <div className={styles.tabs}>
+                  {CATEGORY_IDS.map((cat) => (
+                    <button
+                      key={cat}
+                      onClick={() => {
+                        setActiveCategory(cat);
+                        setOpenIndex(0);
+                      }}
+                      className={`${styles.tab} ${activeCategory === cat ? styles.tabActive : ""}`}
+                    >
+                      {t(CATEGORY_LABEL_KEYS[cat])}
+                      <span className={`${styles.tabCount} ${activeCategory === cat ? styles.tabCountActive : ""}`}>
+                        {faqData[cat].length}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className={styles.categoryLabel}>
+                  {t("categoryQuestions", {
+                    category: t(CATEGORY_LABEL_KEYS[activeCategory]).toUpperCase(),
+                    count: questions.length,
+                  })}
+                </div>
+
+                <div className={styles.accordion}>
+                  {questions.map((item, i) => (
+                    <div key={i} className={styles.accordionItem}>
+                      <button
+                        onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                        className={styles.accordionHeader}
+                      >
+                        <span className={styles.questionText}>{item.question}</span>
+                        <div className={`${styles.chevron} ${openIndex === i ? styles.chevronOpen : ""}`}>
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M6 9l6 6 6-6"/>
+                          </svg>
+                        </div>
+                      </button>
+                      {openIndex === i && (
+                        <div className={styles.accordionBody}>
+                          <p className={styles.answerText}>{item.answer}</p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <a
+                  href={`https://wa.me/60127126128?text=${encodeURIComponent("Hi, I have a question about buying a motorcycle")}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.bottomBtn}
+                >
+                  <strong>{t("stillQuestions")}</strong>
+                  <span className={styles.bottomSubtext}>{t("stillQuestionsSubtext")}</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <SiteFooter />
+      <MobileBar />
+    </div>
+  );
+}

--- a/app/[locale]/faq/page.js
+++ b/app/[locale]/faq/page.js
@@ -1,128 +1,26 @@
-"use client";
-import { useState } from "react";
-import { useTranslations } from "next-intl";
-import SiteHeader from "@/app/components/motorkekal/SiteHeader";
-import SiteFooter from "@/app/components/motorkekal/SiteFooter";
-import MobileBar from "@/app/components/motorkekal/MobileBar";
-import styles from "./faq.module.css";
+import { setRequestLocale } from "next-intl/server";
+import FAQContent from "./FAQContent";
+import { localeAlternates } from "@/utils/seoAlternates";
 
-// Category ids map to message-catalog keys (data arrays + display label).
-const CATEGORY_IDS = ["financing", "delivery", "warranty"];
-const CATEGORY_LABEL_KEYS = {
-  financing: "categories.Financing",
-  delivery: "categories.Delivery",
-  warranty: "categories.Warranty",
-};
-
-export default function FAQPage() {
-  const t = useTranslations("faq");
-  const [activeCategory, setActiveCategory] = useState(CATEGORY_IDS[0]);
-  const [openIndex, setOpenIndex] = useState(0);
-
-  // Pull localized question/answer arrays from the message catalog.
-  const faqData = CATEGORY_IDS.reduce((acc, id) => {
-    acc[id] = t.raw(id);
-    return acc;
-  }, {});
-
-  const questions = faqData[activeCategory];
-
-  const faqSchemaData = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: CATEGORY_IDS.flatMap((id) => faqData[id]).map((item) => ({
-      "@type": "Question",
-      name: item.question,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.answer,
-      },
-    })),
+// Server wrapper so the FAQ page gets its own metadata — without this the
+// client component inherited the layout's, which canonicalized /faq to "/".
+export function generateMetadata({ params: { locale } }) {
+  return {
+    title: "FAQ - Loan Motor, Penghantaran & Waranti",
+    description:
+      "Soalan lazim pasal beli motor di Perniagaan Motor Kekal, Johor Bahru — pembiayaan & loan motor, dokumen diperlukan, penghantaran, waranti dan servis.",
+    keywords: [
+      "loan motor johor bahru",
+      "cara beli motor",
+      "dokumen loan motor",
+      "waranti motor baru",
+      "faq kedai motor",
+    ],
+    alternates: localeAlternates("/faq", locale),
   };
+}
 
-  return (
-    <div className="wrapper">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchemaData) }}
-      />
-      <SiteHeader />
-
-      <section className={styles.faqSection}>
-        <div className="container">
-          <div className="row justify-content-center">
-            <div className="col-lg-8 col-xl-7">
-              <div className={styles.content}>
-                <h1 className={styles.heading}>
-                  {t("heading")}<br />{t("headingLine2")}
-                </h1>
-                <p className={styles.subtext}>{t("subtext")}</p>
-
-                <div className={styles.tabs}>
-                  {CATEGORY_IDS.map((cat) => (
-                    <button
-                      key={cat}
-                      onClick={() => {
-                        setActiveCategory(cat);
-                        setOpenIndex(0);
-                      }}
-                      className={`${styles.tab} ${activeCategory === cat ? styles.tabActive : ""}`}
-                    >
-                      {t(CATEGORY_LABEL_KEYS[cat])}
-                      <span className={`${styles.tabCount} ${activeCategory === cat ? styles.tabCountActive : ""}`}>
-                        {faqData[cat].length}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-
-                <div className={styles.categoryLabel}>
-                  {t("categoryQuestions", {
-                    category: t(CATEGORY_LABEL_KEYS[activeCategory]).toUpperCase(),
-                    count: questions.length,
-                  })}
-                </div>
-
-                <div className={styles.accordion}>
-                  {questions.map((item, i) => (
-                    <div key={i} className={styles.accordionItem}>
-                      <button
-                        onClick={() => setOpenIndex(openIndex === i ? null : i)}
-                        className={styles.accordionHeader}
-                      >
-                        <span className={styles.questionText}>{item.question}</span>
-                        <div className={`${styles.chevron} ${openIndex === i ? styles.chevronOpen : ""}`}>
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                            <path d="M6 9l6 6 6-6"/>
-                          </svg>
-                        </div>
-                      </button>
-                      {openIndex === i && (
-                        <div className={styles.accordionBody}>
-                          <p className={styles.answerText}>{item.answer}</p>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-
-                <a
-                  href={`https://wa.me/60127126128?text=${encodeURIComponent("Hi, I have a question about buying a motorcycle")}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.bottomBtn}
-                >
-                  <strong>{t("stillQuestions")}</strong>
-                  <span className={styles.bottomSubtext}>{t("stillQuestionsSubtext")}</span>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <SiteFooter />
-      <MobileBar />
-    </div>
-  );
+export default function FAQPage({ params: { locale } }) {
+  setRequestLocale(locale);
+  return <FAQContent />;
 }

--- a/app/[locale]/layout.js
+++ b/app/[locale]/layout.js
@@ -25,8 +25,7 @@ export function generateStaticParams() {
 
 export const metadata = {
   title: {
-    default:
-      "Kedai Motor Johor Jaya | Perniagaan Motor Kekal - Motorcycle Dealer JB",
+    default: "Kedai Motor Johor Jaya & JB | Perniagaan Motor Kekal",
     template: "%s | Perniagaan Motor Kekal",
   },
   description:
@@ -56,18 +55,12 @@ export const metadata = {
     telephone: false,
   },
   metadataBase: new URL("https://www.motorkekal.com"),
-  alternates: {
-    canonical: "/",
-    languages: {
-      en: "/",
-      ms: "/ms",
-      zh: "/zh",
-      "x-default": "/",
-    },
-  },
+  // NOTE: no `alternates` here on purpose — a layout-level canonical is
+  // inherited by every page that doesn't define its own, which made subpages
+  // (e.g. /faq) claim the homepage as their canonical. Every page sets its
+  // own canonical + hreflang via localeAlternates() instead.
   openGraph: {
-    title:
-      "Kedai Motor Johor Jaya | Perniagaan Motor Kekal - Motorcycle Dealer JB",
+    title: "Kedai Motor Johor Jaya & JB | Perniagaan Motor Kekal",
     description:
       "Kedai motor Johor Jaya & Johor Bahru yang dipercayai. Jual motor baru Yamaha, Kawasaki, Honda, KTM. Servis & repair. Harga terbaik di JB.",
     url: "https://www.motorkekal.com",
@@ -85,8 +78,7 @@ export const metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title:
-      "Kedai Motor Johor Jaya | Perniagaan Motor Kekal - Motorcycle Dealer JB",
+    title: "Kedai Motor Johor Jaya & JB | Perniagaan Motor Kekal",
     description:
       "Kedai motor Johor Jaya & Johor Bahru yang dipercayai. Jual motor baru Yamaha, Kawasaki, Honda, KTM. Servis & repair. Harga terbaik di JB.",
     images: ["/images/background/website-screenshot.jpeg"],

--- a/app/[locale]/motorcycle/[slug]/page.js
+++ b/app/[locale]/motorcycle/[slug]/page.js
@@ -15,6 +15,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 
 import { getMotorcycleByIdPg as getMotorcycleById } from "@/utils/dbPg";
 import { extractIdFromSlug, toMotorcycleSlug } from "@/utils/slug";
+import { localeAlternates } from "@/utils/seoAlternates";
 import ProductSchema from "@/app/components/seo/ProductSchema";
 import BreadcrumbSchema from "@/app/components/seo/BreadcrumbSchema";
 
@@ -61,9 +62,7 @@ export async function generateMetadata({ params }) {
         "kedai motor johor jaya",
         `${motorcycleData.brand} dealer`,
       ],
-      alternates: {
-        canonical: `/motorcycle/${slug}`,
-      },
+      alternates: localeAlternates(`/motorcycle/${slug}`, params.locale),
       openGraph: {
         title: `${motorcycleData.name} - RM${motorcycleData.price}`,
         description: `${motorcycleData.name} for sale at RM${motorcycleData.price}. Trusted motorcycle dealer in Johor Bahru.`,

--- a/app/[locale]/page.js
+++ b/app/[locale]/page.js
@@ -1,6 +1,26 @@
 import { setRequestLocale } from "next-intl/server";
 import Home from "./home/page";
 import Wrapper from "@/app/layout/wrapper";
+import { localeAlternates } from "@/utils/seoAlternates";
+
+// Locale-specific homepage meta. en/ms fall back to the layout defaults
+// (already written in Malay/English mix); zh gets a native title since the
+// Chinese homepage is the site's best-performing page in search.
+const HOME_META = {
+  zh: {
+    // Runs through the layout's "%s | Perniagaan Motor Kekal" template.
+    title: "新山摩托车行 - 新车·维修·保养",
+    description:
+      "柔佛再也（新山）超过30年的摩托车行。出售 Yamaha、Honda、Kawasaki、KTM 新车，提供贷款、维修保养、保险与路税服务。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  return {
+    ...(HOME_META[locale] || {}),
+    alternates: localeAlternates("/", locale),
+  };
+}
 
 export default function MainRoot({ params: { locale } }) {
   // Enable static rendering for this locale.

--- a/app/components/motorkekal/SiteFooter.js
+++ b/app/components/motorkekal/SiteFooter.js
@@ -32,6 +32,8 @@ const SiteFooter = () => {
             <Link href="/promotions">{t("nav.promotions")}</Link>
             <Link href="/service">{t("nav.ourServices")}</Link>
             <Link href="/about-us">{t("nav.aboutUs")}</Link>
+            <Link href="/faq">{t("nav.faq")}</Link>
+            <Link href="/contact">{t("nav.contact")}</Link>
           </div>
 
           <div>

--- a/app/components/seo/ProductSchema.js
+++ b/app/components/seo/ProductSchema.js
@@ -1,8 +1,14 @@
+import { toMotorcycleSlug } from "@/utils/slug";
+
 const ProductSchema = ({ motorcycle }) => {
+  const url = `https://www.motorkekal.com/motorcycle/${toMotorcycleSlug(
+    motorcycle
+  )}`;
   const productData = {
     "@context": "https://schema.org",
     "@type": "Product",
     name: motorcycle.name,
+    url,
     description:
       motorcycle.description ||
       `${motorcycle.name} for sale at Perniagaan Motor Kekal, Johor Bahru.`,
@@ -13,9 +19,11 @@ const ProductSchema = ({ motorcycle }) => {
     image: motorcycle.images?.[0]?.url || motorcycle.imageUrl,
     offers: {
       "@type": "Offer",
+      url,
       price: motorcycle.price,
       priceCurrency: "MYR",
       availability: "https://schema.org/InStock",
+      itemCondition: "https://schema.org/NewCondition",
       seller: {
         "@type": "Organization",
         name: "Perniagaan Motor Kekal",

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,101 +1,55 @@
 import { listMotorcyclesPg as listMotorcycles } from "@/utils/dbPg";
 import { toMotorcycleSlug } from "@/utils/slug";
+import { routing } from "@/i18n/routing";
 
 const URL = "https://www.motorkekal.com";
+
+// Expand a path into one entry per locale, honoring next-intl's prefix-free
+// default locale: "/service" → "/service", "/ms/service", "/zh/service".
+function localeEntries(path, opts) {
+  const suffix = path === "/" ? "" : path;
+  return routing.locales.map((locale) => ({
+    url:
+      locale === routing.defaultLocale
+        ? `${URL}${suffix}`
+        : `${URL}/${locale}${suffix}`,
+    lastModified: new Date().toISOString(),
+    ...opts,
+  }));
+}
+
+const STATIC_ROUTES = [
+  ["/", { changeFrequency: "daily", priority: 1.0 }],
+  ["/listing", { changeFrequency: "daily", priority: 0.9 }],
+  ["/promotions", { changeFrequency: "daily", priority: 0.8 }],
+  ["/about-us", { changeFrequency: "monthly", priority: 0.7 }],
+  ["/contact", { changeFrequency: "monthly", priority: 0.6 }],
+  ["/service", { changeFrequency: "monthly", priority: 0.6 }],
+  ["/faq", { changeFrequency: "monthly", priority: 0.5 }],
+];
+
+function staticEntries() {
+  return STATIC_ROUTES.flatMap(([path, opts]) => localeEntries(path, opts));
+}
 
 export default async function sitemap() {
   try {
     const motorcycleData = await listMotorcycles();
 
-    const motorcycles = motorcycleData.map((motorcycle) => ({
-      url: `${URL}/motorcycle/${toMotorcycleSlug(motorcycle)}`,
-      lastModified: motorcycle.updatedAt
-        ? new Date(motorcycle.updatedAt).toISOString()
-        : new Date().toISOString(),
-      changeFrequency: "weekly",
-      priority: 0.8,
-    }));
-
-    const routes = [
-      {
-        url: `${URL}`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
-        priority: 1.0,
-      },
-      {
-        url: `${URL}/listing`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
-        priority: 0.9,
-      },
-      {
-        url: `${URL}/promotions`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
+    const motorcycles = motorcycleData.flatMap((motorcycle) =>
+      localeEntries(`/motorcycle/${toMotorcycleSlug(motorcycle)}`, {
+        lastModified: motorcycle.updatedAt
+          ? new Date(motorcycle.updatedAt).toISOString()
+          : new Date().toISOString(),
+        changeFrequency: "weekly",
         priority: 0.8,
-      },
-      {
-        url: `${URL}/about-us`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.7,
-      },
-      {
-        url: `${URL}/contact`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.6,
-      },
-      {
-        url: `${URL}/service`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.6,
-      },
-    ];
+      })
+    );
 
-    return [...routes, ...motorcycles];
+    return [...staticEntries(), ...motorcycles];
   } catch (error) {
     console.error("Error generating sitemap:", error);
     // Return basic routes if database fails
-    return [
-      {
-        url: `${URL}`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
-        priority: 1.0,
-      },
-      {
-        url: `${URL}/listing`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
-        priority: 0.9,
-      },
-      {
-        url: `${URL}/promotions`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "daily",
-        priority: 0.8,
-      },
-      {
-        url: `${URL}/about-us`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.7,
-      },
-      {
-        url: `${URL}/contact`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.6,
-      },
-      {
-        url: `${URL}/service`,
-        lastModified: new Date().toISOString(),
-        changeFrequency: "monthly",
-        priority: 0.6,
-      },
-    ];
+    return staticEntries();
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -703,6 +703,26 @@
       "ctaText": "Come to our Johor Bahru shop for a test ride, or WhatsApp us to reserve a unit and get exact installment figures.",
       "ctaWhatsApp": "WhatsApp Motor Kekal"
     },
-    "visitFacebook": "Visit our Facebook"
+    "visitFacebook": "Visit our Facebook",
+    "contact": {
+      "crumbCurrent": "Contact",
+      "eyebrow": "Contact us",
+      "heading": "Drop by the shop — or WhatsApp us first",
+      "sub": "We're in Taman Johor Bahru, right by Johor Jaya. Call, message or just come by — no appointment needed.",
+      "callTitle": "Call us",
+      "callDesc": "Talk to us directly about bikes, loans or servicing.",
+      "waTitle": "WhatsApp us",
+      "waDesc": "Fastest way to reach us — send photos, get quotes, check loan eligibility.",
+      "waCta": "Start a chat",
+      "visitTitle": "Visit the showroom",
+      "visitDesc": "Free parking right in front of the shop.",
+      "visitCta": "Get directions",
+      "hoursTitle": "Opening hours",
+      "hoursValue": "9:00 AM – 7:00 PM, daily (closed Friday)",
+      "hoursNote": "Closed on some public holidays — WhatsApp us before coming.",
+      "findEyebrow": "Find us",
+      "findHeading": "Perniagaan Motor Kekal, Johor Bahru",
+      "waPrefill": "Hi Motor Kekal, I'd like to ask about a motorcycle."
+    }
   }
 }

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -703,6 +703,26 @@
       "ctaText": "Datang ke kedai Johor Bahru kami untuk test rasa, atau WhatsApp kami untuk tahan unit dan dapatkan angka ansuran tepat.",
       "ctaWhatsApp": "WhatsApp Motor Kekal"
     },
-    "visitFacebook": "Lawati Facebook kami"
+    "visitFacebook": "Lawati Facebook kami",
+    "contact": {
+      "crumbCurrent": "Hubungi",
+      "eyebrow": "Hubungi kami",
+      "heading": "Singgah kedai — atau WhatsApp kami dulu",
+      "sub": "Kami di Taman Johor Bahru, sebelah Johor Jaya. Call, mesej atau terus datang — tak perlu appointment.",
+      "callTitle": "Call kami",
+      "callDesc": "Cakap terus dengan kami pasal motor, loan atau servis.",
+      "waTitle": "WhatsApp kami",
+      "waDesc": "Cara paling cepat hubungi kami — hantar gambar, dapatkan harga, semak kelayakan loan.",
+      "waCta": "Mula chat",
+      "visitTitle": "Datang ke showroom",
+      "visitDesc": "Parking percuma betul-betul depan kedai.",
+      "visitCta": "Dapatkan arah",
+      "hoursTitle": "Waktu operasi",
+      "hoursValue": "9:00 pagi – 7:00 malam, setiap hari (Jumaat tutup)",
+      "hoursNote": "Tutup pada sesetengah cuti umum — WhatsApp kami sebelum datang.",
+      "findEyebrow": "Cari kami",
+      "findHeading": "Perniagaan Motor Kekal, Johor Bahru",
+      "waPrefill": "Hi Motor Kekal, saya nak tanya pasal motosikal."
+    }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -703,6 +703,26 @@
       "ctaText": "欢迎到我们新山的店试骑，或通过 WhatsApp 预留车辆并获取准确的分期金额。",
       "ctaWhatsApp": "WhatsApp Motor Kekal"
     },
-    "visitFacebook": "访问我们的 Facebook"
+    "visitFacebook": "访问我们的 Facebook",
+    "contact": {
+      "crumbCurrent": "联系我们",
+      "eyebrow": "联系我们",
+      "heading": "欢迎到店参观 — 或先 WhatsApp 我们",
+      "sub": "我们位于 Taman Johor Bahru，就在柔佛再也旁边。打电话、发信息或直接过来——无需预约。",
+      "callTitle": "打电话",
+      "callDesc": "直接与我们聊摩托车、贷款或维修保养。",
+      "waTitle": "WhatsApp 我们",
+      "waDesc": "最快的联系方式——发照片、询价、查贷款资格。",
+      "waCta": "开始聊天",
+      "visitTitle": "到店参观",
+      "visitDesc": "店门口有免费停车位。",
+      "visitCta": "获取路线",
+      "hoursTitle": "营业时间",
+      "hoursValue": "每天上午9点 – 晚上7点（周五休息）",
+      "hoursNote": "部分公共假期休息——来之前请先 WhatsApp 我们。",
+      "findEyebrow": "找到我们",
+      "findHeading": "Perniagaan Motor Kekal 新山",
+      "waPrefill": "Hi Motor Kekal, 我想询问摩托车。"
+    }
   }
 }

--- a/utils/seoAlternates.js
+++ b/utils/seoAlternates.js
@@ -1,0 +1,19 @@
+import { routing } from "@/i18n/routing";
+
+// Build a self-referencing canonical plus hreflang alternates for a route,
+// honoring next-intl's localePrefix "as-needed" (default locale is
+// prefix-free, e.g. "/service" vs "/ms/service"). Paths are resolved against
+// metadataBase from the root layout.
+export function localeAlternates(path, locale = routing.defaultLocale) {
+  const suffix = path === "/" ? "" : path;
+  const localePath = (loc) =>
+    loc === routing.defaultLocale ? path : `/${loc}${suffix}`;
+
+  const languages = {};
+  for (const loc of routing.locales) {
+    languages[loc] = localePath(loc);
+  }
+  languages["x-default"] = path;
+
+  return { canonical: localePath(locale), languages };
+}


### PR DESCRIPTION
## Why

GSC (last 3 months) shows avg position 7.8 with **0.56% CTR** (~3% expected at that position). An audit found several indexing-level bugs plus missed local/hreflang signals.

## What

- **Rebuilt `/contact`** — it had no route, fell into the catch-all, and served 404 content with HTTP 200 while still ranking (182 impressions @ pos 7.5). Now a real storefront contact page in en/ms/zh: contact cards (call / WhatsApp / visit / hours), map + NAP block.
- **Fixed `/faq` metadata** — client page had no metadata export, so it inherited the layout's `canonical: "/"` and declared itself a duplicate of the homepage. Split into a server wrapper (own title/description/canonical) + `FAQContent` client component.
- **Self-canonical + hreflang everywhere** — ms/zh pages canonicalized cross-language to the en URL (against Google guidance, and `/zh` is the site's best CTR page at 6.9%). New `utils/seoAlternates.js` helper generates locale-aware canonical + en/ms/zh/x-default hreflang; applied to home, listing, promotions, about, service, faq, contact, and motorcycle detail. Removed the layout-level canonical that subpages silently inherited.
- **Real 404s** — unknown URLs returned HTTP 200 (soft 404). The `[...not_found]` catch-all now throws `notFound()` so the boundary renders with a 404 status.
- **Sitemap** — includes ms/zh variants of every route plus `/faq` (and `/contact` now resolves to a real page).
- **CTR pass** — homepage title 71→52 chars (was truncated in SERPs); native Chinese title/description for `/zh`; Product schema gains `url` + `itemCondition`; footer now links FAQ and Contact (previously orphaned).

## Verification

- `yarn lint` + `yarn build` pass (all locale routes generated)
- Verified on a local prod server: `/contact` 200 with content in all 3 locales, unknown URL → **404**, `/faq` has own title + canonical, `/ms/service` canonical is `/ms/service` with full hreflang set, sitemap contains locale variants, zh homepage title renders
- Playwright visual check: contact page renders correctly at desktop + mobile widths, no horizontal overflow

## Follow-ups (not in this PR)

- Opening-hours conflict: footer says Mon–Sun, schema/about say closed Friday — needs owner confirmation
- `aggregateRating` (review stars) pending real Google rating/review count
- Brand landing pages (`/brands/yamaha` …) to catch the hundreds of "yamaha/honda/kawasaki … johor bahru" queries at pos 8–11
- After merge: resubmit sitemap in GSC and request indexing for /contact, /faq and locale pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)