### PR TITLE
fix(brands): paginate bike grid, fix CTA alignment, ISR, i18n gaps

### DIFF
--- a/app/[locale]/(pages)/brands/[brand]/page.js
+++ b/app/[locale]/(pages)/brands/[brand]/page.js
@@ -5,7 +5,7 @@ import { Link } from "@/i18n/navigation";
 import SiteHeader from "@/app/components/motorkekal/SiteHeader";
 import SiteFooter from "@/app/components/motorkekal/SiteFooter";
 import MobileBar from "@/app/components/motorkekal/MobileBar";
-import BikeCard from "@/app/components/motorkekal/BikeCard";
+import BrandBikeGrid from "@/app/components/motorkekal/BrandBikeGrid";
 import BreadcrumbSchema from "@/app/components/seo/BreadcrumbSchema";
 import BrandCollectionSchema from "@/app/components/seo/BrandCollectionSchema";
 import { localeAlternates } from "@/utils/seoAlternates";
@@ -13,7 +13,10 @@ import { queryMotorcyclePg } from "@/utils/dbPg";
 import brandContent, { BRAND_SLUGS } from "@/utils/brandContent";
 import { waLink, WaIcon } from "@/app/components/motorkekal/waLink";
 
-export const dynamic = "force-dynamic";
+// ISR instead of force-dynamic: force-dynamic crashes dev under the static
+// [locale] layout (Next 13.4 "Dynamic server usage" error) and the build
+// ignored it anyway. Stock changes show up within the hour.
+export const revalidate = 3600;
 
 export function generateMetadata({ params: { locale, brand } }) {
   const content = brandContent[brand];
@@ -79,17 +82,17 @@ function BrandDetailContent({ locale, brand, content, motorcycles }) {
       <main>
         {/* Hero */}
         <section className="section wrap">
-          <nav className="breadcrumb" aria-label="Breadcrumb">
-            <Link href="/">Home</Link>
-            <span aria-hidden="true"> / </span>
+          <nav className="crumbs" aria-label="Breadcrumb">
+            <Link href="/">{t("breadcrumbHome")}</Link>
+            <span>›</span>
             <Link href="/brands">{t("breadcrumbBrands")}</Link>
-            <span aria-hidden="true"> / </span>
-            <span>{content.displayName}</span>
+            <span>›</span>
+            {content.displayName}
           </nav>
 
           <div className="section-head" style={{ marginTop: 24 }}>
             <p className="eyebrow">{t("eyebrow")}</p>
-            <h1>{content.displayName} Motorcycles</h1>
+            <h1>{t("detailHeading", { brand: content.displayName })}</h1>
             <p className="hero__sub">{loc.intro}</p>
           </div>
         </section>
@@ -97,11 +100,7 @@ function BrandDetailContent({ locale, brand, content, motorcycles }) {
         {/* Bike grid */}
         <section className="section wrap">
           {motorcycles.length > 0 ? (
-            <div className="bike-grid">
-              {motorcycles.map((moto) => (
-                <BikeCard key={moto.id} motorcycle={moto} />
-              ))}
-            </div>
+            <BrandBikeGrid motorcycles={motorcycles} />
           ) : (
             <div className="card" style={{ padding: 32, textAlign: "center" }}>
               <h2 style={{ marginBottom: 8 }}>{t("noStock", { brand: content.displayName })}</h2>
@@ -127,7 +126,7 @@ function BrandDetailContent({ locale, brand, content, motorcycles }) {
             <h2>
               {t("ctaWhatsApp", { brand: content.displayName })}
             </h2>
-            <div style={{ display: "flex", gap: 12, flexWrap: "wrap", justifyContent: "center" }}>
+            <div className="cta-band__actions">
               <a
                 className="btn btn--wa btn--lg"
                 href={waLink(`Hi Motor Kekal, saya berminat dengan motosikal ${content.displayName}. Boleh bagi info lanjut?`)}

--- a/app/[locale]/(pages)/brands/page.js
+++ b/app/[locale]/(pages)/brands/page.js
@@ -10,22 +10,27 @@ import { localeAlternates } from "@/utils/seoAlternates";
 import brandContent, { BRAND_SLUGS } from "@/utils/brandContent";
 import { queryMotorcyclePg } from "@/utils/dbPg";
 
-export const dynamic = "force-dynamic";
+// ISR instead of force-dynamic: force-dynamic crashes dev under the static
+// [locale] layout (Next 13.4 "Dynamic server usage" error) and the build
+// ignored it anyway — counts were frozen at deploy time. Refreshes hourly.
+export const revalidate = 3600;
 
 export function generateMetadata({ params: { locale } }) {
+  // Brand name is appended by the layout's "%s | Perniagaan Motor Kekal"
+  // title template — don't repeat it here.
   const meta = {
     en: {
-      title: "Motorcycle Brands | Perniagaan Motor Kekal Johor Bahru",
+      title: "Motorcycle Brands in Johor Bahru",
       description:
         "Authorized dealer for Yamaha, Honda, Kawasaki & KTM motorcycles in Johor Bahru. Browse all brands and find your next bike at Motor Kekal.",
     },
     ms: {
-      title: "Jenama Motosikal | Perniagaan Motor Kekal Johor Bahru",
+      title: "Jenama Motosikal di Johor Bahru",
       description:
         "Dealer rasmi motosikal Yamaha, Honda, Kawasaki & KTM di Johor Bahru. Lihat semua jenama dan cari motosikal anda di Motor Kekal.",
     },
     zh: {
-      title: "摩托车品牌 | Perniagaan Motor Kekal 新山",
+      title: "新山摩托车品牌",
       description:
         "新山 Yamaha、Honda、Kawasaki 及 KTM 摩托车授权经销商。浏览所有品牌，在 Motor Kekal 找到您的下一辆摩托车。",
     },
@@ -92,7 +97,16 @@ function BrandsIndexContent({ locale, counts }) {
                   className="card card--hover svc-card"
                   style={{ textDecoration: "none" }}
                 >
-                  <div className="svc-card__ico">
+                  <div
+                    className="svc-card__ico"
+                    // Text fallback ("Kawasaki") is wider than the 52px
+                    // chip — let it grow into a pill instead of overflowing.
+                    style={
+                      brand.logo
+                        ? undefined
+                        : { width: "auto", minWidth: 52, paddingInline: 12 }
+                    }
+                  >
                     {brand.logo ? (
                       <Image
                         src={brand.logo}
@@ -102,7 +116,7 @@ function BrandsIndexContent({ locale, counts }) {
                         style={{ objectFit: "contain" }}
                       />
                     ) : (
-                      <span style={{ fontSize: 20, fontWeight: 700 }}>
+                      <span style={{ fontSize: 18, fontWeight: 700 }}>
                         {brand.displayName}
                       </span>
                     )}

--- a/app/[locale]/(pages)/promotions/page.js
+++ b/app/[locale]/(pages)/promotions/page.js
@@ -9,8 +9,10 @@ import { listLivePromotionsPg, listPastPromotionsPg } from "@/utils/dbPg";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import { localeAlternates } from "@/utils/seoAlternates";
 
-// Promotions are time-sensitive; always render the current live set.
-export const dynamic = "force-dynamic";
+// Promotions are time-sensitive. ISR every 5 minutes — the previous
+// force-dynamic crashed dev under the static [locale] layout and was
+// ignored by the build anyway (page was fully frozen at deploy time).
+export const revalidate = 300;
 
 export function generateMetadata({ params: { locale } }) {
   return {

--- a/app/[locale]/motorcycle/[slug]/page.js
+++ b/app/[locale]/motorcycle/[slug]/page.js
@@ -222,15 +222,7 @@ const MotorcyclePage = async ({ params }) => {
           <div className="cta-band">
             <h2>{t("ctaTitle")}</h2>
             <p>{t("ctaText")}</p>
-            <div
-              style={{
-                display: "flex",
-                gap: 12,
-                justifyContent: "center",
-                flexWrap: "wrap",
-                marginTop: 26,
-              }}
-            >
+            <div className="cta-band__actions">
               <a
                 className="btn btn--wa btn--lg"
                 href={waLink(ctaMessage)}

--- a/app/components/auth/AuthProvider.js
+++ b/app/components/auth/AuthProvider.js
@@ -27,7 +27,6 @@ export function AuthProvider({ children }) {
         const data = docSnap.data();
         // Assuming the document contains an array field called 'emails'
         const emails = data.authorizedReceiptEmails || [];
-        console.log({ emails });
         setAuthorizedEmails(emails);
         return emails;
       } else {

--- a/app/components/motorkekal/BrandBikeGrid.js
+++ b/app/components/motorkekal/BrandBikeGrid.js
@@ -1,0 +1,45 @@
+"use client";
+import { useRef, useState } from "react";
+import BikeCard from "./BikeCard";
+import Pagination from "@/app/components/common/Pagination";
+
+// Same page size as the main listing (utils/hooks/useMotorcyclesPg.js).
+const ITEMS_PER_PAGE = 8;
+
+// Client-side paginated grid for brand pages. The full brand inventory is
+// fetched server-side for SEO; we only paginate the rendering.
+const BrandBikeGrid = ({ motorcycles }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const gridRef = useRef(null);
+
+  const totalPages = Math.ceil(motorcycles.length / ITEMS_PER_PAGE);
+  const start = (currentPage - 1) * ITEMS_PER_PAGE;
+  const visible = motorcycles.slice(start, start + ITEMS_PER_PAGE);
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+    gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  return (
+    <div ref={gridRef} style={{ scrollMarginTop: 90 }}>
+      <div className="bike-grid">
+        {visible.map((moto) => (
+          <BikeCard key={moto.id} motorcycle={moto} />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div style={{ marginTop: 30 }}>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            setCurrentPage={handlePageChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BrandBikeGrid;

--- a/app/components/motorkekal/SiteHeader.js
+++ b/app/components/motorkekal/SiteHeader.js
@@ -10,6 +10,7 @@ import { waLink, WaIcon, FbIcon, FACEBOOK_URL } from "./waLink";
 const NAV = [
   { href: "/", key: "home" },
   { href: "/listing", key: "listings" },
+  { href: "/brands", key: "brands" },
   { href: "/promotions", key: "promotions" },
   { href: "/service", key: "ourServices" },
   { href: "/about-us", key: "aboutUs" },

--- a/app/components/motorkekal/motorkekal.css
+++ b/app/components/motorkekal/motorkekal.css
@@ -901,7 +901,18 @@
   max-width: 34em;
   margin-inline: auto;
 }
-.mk-site .cta-band .btn--wa {
+/* Direct child only: bands with a single CTA. Bands with several buttons
+   wrap them in .cta-band__actions, which carries the spacing instead —
+   otherwise only the WA button picked up the margin and sat 26px lower
+   than its siblings. */
+.mk-site .cta-band > .btn--wa {
+  margin-top: 26px;
+}
+.mk-site .cta-band__actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
   margin-top: 26px;
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,8 @@
     "ourServices": "Our Services",
     "faq": "FAQ",
     "menu": "Menu",
-    "promotions": "Promotions"
+    "promotions": "Promotions",
+    "brands": "Brands"
   },
   "headerTop": {
     "hours": "Mon – Thu, Sat – Sun 9AM - 7PM (Fri Closed)",
@@ -735,6 +736,8 @@
     "ctaWhatsApp": "Ask about {brand}",
     "viewAll": "View all motorcycles",
     "exploreOtherBrands": "Explore other brands",
-    "eyebrow": "Authorized Dealer · Johor Bahru"
+    "eyebrow": "Authorized Dealer · Johor Bahru",
+    "breadcrumbHome": "Home",
+    "detailHeading": "{brand} Motorcycles"
   }
 }

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -9,7 +9,8 @@
     "ourServices": "Servis Kami",
     "faq": "Soalan Lazim",
     "menu": "Menu",
-    "promotions": "Promosi"
+    "promotions": "Promosi",
+    "brands": "Jenama"
   },
   "headerTop": {
     "hours": "Isn – Kha, Sab – Ahd 9AM - 7PM (Jumaat Tutup)",
@@ -735,6 +736,8 @@
     "ctaWhatsApp": "Tanya tentang {brand}",
     "viewAll": "Lihat semua motosikal",
     "exploreOtherBrands": "Terokai jenama lain",
-    "eyebrow": "Dealer Rasmi · Johor Bahru"
+    "eyebrow": "Dealer Rasmi · Johor Bahru",
+    "breadcrumbHome": "Utama",
+    "detailHeading": "Motosikal {brand}"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -9,7 +9,8 @@
     "ourServices": "我们的服务",
     "faq": "常见问题",
     "menu": "菜单",
-    "promotions": "促销"
+    "promotions": "促销",
+    "brands": "品牌"
   },
   "headerTop": {
     "hours": "周一至周四、周六至周日 9AM - 7PM（周五休息）",
@@ -735,6 +736,8 @@
     "ctaWhatsApp": "咨询 {brand}",
     "viewAll": "查看所有摩托车",
     "exploreOtherBrands": "探索其他品牌",
-    "eyebrow": "授权经销商 · 新山"
+    "eyebrow": "授权经销商 · 新山",
+    "breadcrumbHome": "首页",
+    "detailHeading": "{brand} 摩托车"
   }
 }

--- a/utils/brandContent.js
+++ b/utils/brandContent.js
@@ -5,7 +5,7 @@ const brandContent = {
     displayName: "Yamaha",
     logo: "/images/listing/YamahaLogo.png",
     en: {
-      title: "Yamaha Dealer Johor Bahru | Perniagaan Motor Kekal",
+      title: "Yamaha Dealer Johor Bahru",
       description:
         "Authorized Yamaha motorcycle dealer in Johor Bahru. Browse new Yamaha bikes — NMax, Y16ZR, YZF-R15 & more. Best price, easy financing, genuine parts.",
       intro:
@@ -20,7 +20,7 @@ const brandContent = {
       ],
     },
     ms: {
-      title: "Dealer Yamaha Johor Bahru | Perniagaan Motor Kekal",
+      title: "Dealer Yamaha Johor Bahru",
       description:
         "Dealer rasmi motosikal Yamaha di Johor Bahru. Lihat stok Yamaha terkini — NMax, Y16ZR, YZF-R15 & lain-lain. Harga terbaik, pembiayaan mudah.",
       intro:
@@ -34,7 +34,7 @@ const brandContent = {
       ],
     },
     zh: {
-      title: "新山 Yamaha 经销商 | Perniagaan Motor Kekal",
+      title: "新山 Yamaha 经销商",
       description:
         "新山授权 Yamaha 摩托车经销商。浏览最新 Yamaha 车型 — NMax、Y16ZR、YZF-R15 等。最优价格，轻松融资，原厂配件。",
       intro:
@@ -50,7 +50,7 @@ const brandContent = {
     displayName: "Honda",
     logo: "/images/listing/HondaLogo.png",
     en: {
-      title: "Honda Dealer Johor Bahru | Perniagaan Motor Kekal",
+      title: "Honda Dealer Johor Bahru",
       description:
         "Authorized Honda motorcycle dealer in Johor Bahru. New Honda bikes — Wave, EX5, RS150R, ADV & more. Competitive pricing with flexible financing.",
       intro:
@@ -65,7 +65,7 @@ const brandContent = {
       ],
     },
     ms: {
-      title: "Dealer Honda Johor Bahru | Perniagaan Motor Kekal",
+      title: "Dealer Honda Johor Bahru",
       description:
         "Dealer rasmi motosikal Honda di Johor Bahru. Stok Honda terkini — Wave, EX5, RS150R, ADV & lain-lain. Harga berpatutan, pembiayaan fleksibel.",
       intro:
@@ -79,7 +79,7 @@ const brandContent = {
       ],
     },
     zh: {
-      title: "新山 Honda 经销商 | Perniagaan Motor Kekal",
+      title: "新山 Honda 经销商",
       description:
         "新山授权 Honda 摩托车经销商。最新 Honda 车型 — Wave、EX5、RS150R、ADV 等。价格优惠，灵活融资。",
       intro:
@@ -95,7 +95,7 @@ const brandContent = {
     displayName: "Kawasaki",
     logo: null,
     en: {
-      title: "Kawasaki Dealer Johor Bahru | Perniagaan Motor Kekal",
+      title: "Kawasaki Dealer Johor Bahru",
       description:
         "Kawasaki motorcycle dealer in Johor Bahru. Browse Ninja, Z series, Versys & more. Sport bikes and adventure motorcycles with full service support.",
       intro:
@@ -110,7 +110,7 @@ const brandContent = {
       ],
     },
     ms: {
-      title: "Dealer Kawasaki Johor Bahru | Perniagaan Motor Kekal",
+      title: "Dealer Kawasaki Johor Bahru",
       description:
         "Dealer motosikal Kawasaki di Johor Bahru. Lihat Ninja, siri Z, Versys & lain-lain. Motor sukan dan pengembaraan dengan sokongan servis penuh.",
       intro:
@@ -124,7 +124,7 @@ const brandContent = {
       ],
     },
     zh: {
-      title: "新山 Kawasaki 经销商 | Perniagaan Motor Kekal",
+      title: "新山 Kawasaki 经销商",
       description:
         "新山 Kawasaki 摩托车经销商。Ninja、Z系列、Versys 等运动及探险摩托车，提供全面售后服务。",
       intro:
@@ -140,7 +140,7 @@ const brandContent = {
     displayName: "KTM",
     logo: null,
     en: {
-      title: "KTM Dealer Johor Bahru | Perniagaan Motor Kekal",
+      title: "KTM Dealer Johor Bahru",
       description:
         "KTM motorcycle dealer in Johor Bahru. Duke, RC & Adventure series available. Ready-to-race performance with genuine KTM parts and service.",
       intro:
@@ -155,7 +155,7 @@ const brandContent = {
       ],
     },
     ms: {
-      title: "Dealer KTM Johor Bahru | Perniagaan Motor Kekal",
+      title: "Dealer KTM Johor Bahru",
       description:
         "Dealer motosikal KTM di Johor Bahru. Siri Duke, RC & Adventure tersedia. Prestasi siap-lumba dengan alat ganti asli KTM.",
       intro:
@@ -169,7 +169,7 @@ const brandContent = {
       ],
     },
     zh: {
-      title: "新山 KTM 经销商 | Perniagaan Motor Kekal",
+      title: "新山 KTM 经销商",
       description:
         "新山 KTM 摩托车经销商。Duke、RC 及 Adventure 系列。欧洲工程性能，原厂 KTM 配件及服务。",
       intro:


### PR DESCRIPTION
Design review of the new `/brands` pages. Three issues were reported; the review turned up seven more.

## Reported issues

**1. Missing pagination** — brand pages rendered the entire inventory in one endless grid (26 bikes for Honda). New `BrandBikeGrid` client component paginates at 8/page, reusing the existing `Pagination` component from `/listing` so the UX matches. Full inventory is still fetched server-side for SEO; only the rendering paginates.

**2. Buttons misaligned on desktop** — measured at exactly 26px off. Root cause:

```css
.mk-site .cta-band .btn--wa { margin-top: 26px; }
```

That rule was written for the four CTA bands with a *single* button (home, promotions, service, motorcycle detail). The brands band is the first with two buttons in a flex row, so only the WhatsApp button picked up the margin and dropped out of line. They stack on mobile, which is why it only showed on desktop. Now scoped to direct children (`.cta-band > .btn--wa`), with a new `.cta-band__actions` class carrying the spacing for multi-button rows. **This also fixes the same latent bug on the motorcycle detail page** (WhatsApp vs Facebook buttons).

**3. `public/images/listing` assets** — no change; they are *not* safe to remove. `YamahaLogo.png` and `HondaLogo.png` are referenced by `utils/brandContent.js` and render in the icon chips on the `/brands` index. They're easy to miss because /brands was only linked from the footer (fixed below). The dead files (`1.jpg`–`16.jpg`, SYM/Suzuki logos) were already purged in earlier commits.

## Also fixed

- **`force-dynamic` was doing nothing useful** — it crashed dev under the static `[locale]` layout (blank page, "Dynamic server usage" error) *and* the build ignored it: `/[locale]/brands` still emitted as SSG, so the "X motorcycles available" counts were frozen at deploy time. Same latent issue on `/promotions` — the "live" promotions were also frozen. Replaced with ISR: `revalidate = 3600` for brands, `300` for promotions.
- **Double brand in titles** — "Motorcycle Brands | Perniagaan Motor Kekal Johor Bahru **| Perniagaan Motor Kekal**". Page titles repeated the brand already appended by the layout's title template; stripped from both brands pages and all 12 `brandContent` entries.
- **i18n gaps** — `/ms/brands/honda` rendered an English `<h1>Honda Motorcycles</h1>` and a hardcoded "Home" breadcrumb. Now uses new `detailHeading` / `breadcrumbHome` keys in all three catalogs.
- **Breadcrumb style** — used Bootstrap's `.breadcrumb` (cramped ` / ` separators, off-theme) instead of the storefront `.crumbs` used on about/contact.
- **"Kawasaki" text overflowed** its 52px icon chip (90px wide); the text fallback now grows into a pill.
- **Brands missing from header nav** — only linked from the footer, hurting discoverability and internal linking to pages that target brand queries.
- **Security nit** — `AuthProvider.js` logged the admin email whitelist to every visitor's browser console.

## Verification

`yarn lint` and `yarn build` pass. Verified on a local prod server with Playwright at 1280x800 — all checks pass:

| Check | Result |
|---|---|
| Honda page renders 8 cards + pagination; page 2 shows a different set | PASS |
| Brands CTA buttons equal top | 0px offset |
| Motorcycle detail CTA buttons equal top | 0px offset |
| Kawasaki chip no longer overflows | chip 490px, text 81px |
| Header nav has Brands → /brands | PASS |
| `/en/brands` title, brand appears once | "Motorcycle Brands in Johor Bahru \| Perniagaan Motor Kekal" |
| `/ms/brands/honda` h1 + breadcrumb | "Motosikal Honda", "Utama › Jenama › Honda" |
| No email leak in console | PASS |
| Dev-mode smoke test (previously crashed blank) | renders |

🤖 Generated with [Claude Code](https://claude.com/claude-code)