### PR TITLE
Add structured JSON logging for API mutations and auth

### DIFF
--- a/app/api/motorcycles/[id]/route.js
+++ b/app/api/motorcycles/[id]/route.js
@@ -20,7 +20,13 @@ export async function GET(request, { params }) {
 
     return NextResponse.json(motorcycle);
   } catch (error) {
-    console.error("Error fetching motorcycle:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to fetch motorcycle",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to fetch motorcycle" },
       { status: 500 }
@@ -69,6 +75,17 @@ export async function PUT(request, { params }) {
     }
 
     const motorcycle = await updateMotorcyclePg(id, data);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "motorcycle updated",
+        actor: auth.decoded.email,
+        motorcycleId: id,
+        fields: Object.keys(data),
+      })
+    );
+
     return NextResponse.json(motorcycle);
   } catch (error) {
     if (error.code === "P2002") {
@@ -77,7 +94,14 @@ export async function PUT(request, { params }) {
         { status: 409 }
       );
     }
-    console.error("Error updating motorcycle:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to update motorcycle",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to update motorcycle" },
       { status: 500 }
@@ -101,9 +125,29 @@ export async function DELETE(request, { params }) {
     }
 
     await deleteMotorcyclePg(id);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "motorcycle deleted",
+        actor: auth.decoded.email,
+        motorcycleId: id,
+        brand: existing.brand,
+        name: existing.name,
+        year: existing.year,
+      })
+    );
+
     return NextResponse.json({ message: "Motorcycle deleted successfully" });
   } catch (error) {
-    console.error("Error deleting motorcycle:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to delete motorcycle",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to delete motorcycle" },
       { status: 500 }

--- a/app/api/motorcycles/brands/route.js
+++ b/app/api/motorcycles/brands/route.js
@@ -6,7 +6,13 @@ export async function GET() {
     const brandSet = await fetchUniqueBrandSetPg();
     return NextResponse.json({ brands: Array.from(brandSet) });
   } catch (error) {
-    console.error("Error fetching brands:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to fetch brands",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to fetch brands" },
       { status: 500 }

--- a/app/api/motorcycles/count/route.js
+++ b/app/api/motorcycles/count/route.js
@@ -26,7 +26,13 @@ export async function GET(request) {
     const count = await prisma.motorcycle.count({ where });
     return NextResponse.json({ count });
   } catch (error) {
-    console.error("Error counting motorcycles:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to count motorcycles",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json({ error: "Failed to count" }, { status: 500 });
   }
 }

--- a/app/api/motorcycles/route.js
+++ b/app/api/motorcycles/route.js
@@ -3,6 +3,7 @@ import { queryMotorcyclePg, createMotorcyclePg } from "@/utils/dbPg";
 import { verifyAuthToken } from "@/utils/firebaseAdmin";
 
 export async function GET(request) {
+  const startedAt = Date.now();
   try {
     const { searchParams } = new URL(request.url);
 
@@ -80,9 +81,26 @@ export async function GET(request) {
       search: search || undefined,
     });
 
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "motorcycle search",
+        params: Object.fromEntries(searchParams),
+        resultCount: result.motorcycles.length,
+        total: result.total,
+        durationMs: Date.now() - startedAt,
+      })
+    );
+
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Error fetching motorcycles:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to fetch motorcycles",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to fetch motorcycles" },
       { status: 500 }
@@ -137,15 +155,42 @@ export async function POST(request) {
     };
 
     const motorcycle = await createMotorcyclePg(data);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "motorcycle created",
+        actor: auth.decoded.email,
+        motorcycleId: motorcycle.id,
+        brand: data.brand,
+        name: data.name,
+        year: data.year,
+      })
+    );
+
     return NextResponse.json(motorcycle, { status: 201 });
   } catch (error) {
     if (error.code === "P2002") {
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          msg: "duplicate motorcycle rejected",
+          actor: auth.decoded.email,
+        })
+      );
       return NextResponse.json(
         { error: "A motorcycle with this brand, name, and year already exists" },
         { status: 409 }
       );
     }
-    console.error("Error creating motorcycle:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to create motorcycle",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to create motorcycle" },
       { status: 500 }

--- a/app/api/promotions/[id]/route.js
+++ b/app/api/promotions/[id]/route.js
@@ -20,7 +20,13 @@ export async function GET(request, { params }) {
 
     return NextResponse.json(promotion);
   } catch (error) {
-    console.error("Error fetching promotion:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to fetch promotion",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to fetch promotion" },
       { status: 500 }
@@ -92,9 +98,27 @@ export async function PUT(request, { params }) {
     }
 
     const promotion = await updatePromotionPg(id, data);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "promotion updated",
+        actor: auth.decoded.email,
+        promotionId: id,
+        fields: Object.keys(data),
+      })
+    );
+
     return NextResponse.json(promotion);
   } catch (error) {
-    console.error("Error updating promotion:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to update promotion",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to update promotion" },
       { status: 500 }
@@ -118,9 +142,27 @@ export async function DELETE(request, { params }) {
     }
 
     await deletePromotionPg(id);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "promotion deleted",
+        actor: auth.decoded.email,
+        promotionId: id,
+        title: existing.title,
+      })
+    );
+
     return NextResponse.json({ message: "Promotion deleted successfully" });
   } catch (error) {
-    console.error("Error deleting promotion:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to delete promotion",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to delete promotion" },
       { status: 500 }

--- a/app/api/promotions/route.js
+++ b/app/api/promotions/route.js
@@ -21,7 +21,13 @@ export async function GET(request) {
     const promotions = await listLivePromotionsPg();
     return NextResponse.json({ promotions });
   } catch (error) {
-    console.error("Error fetching promotions:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to fetch promotions",
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to fetch promotions" },
       { status: 500 }
@@ -85,9 +91,27 @@ export async function POST(request) {
     }
 
     const promotion = await createPromotionPg(data);
+
+    console.log(
+      JSON.stringify({
+        level: "info",
+        msg: "promotion created",
+        actor: auth.decoded.email,
+        promotionId: promotion.id,
+        title: data.title,
+      })
+    );
+
     return NextResponse.json(promotion, { status: 201 });
   } catch (error) {
-    console.error("Error creating promotion:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to create promotion",
+        actor: auth.decoded.email,
+        err: { message: error.message, code: error.code, stack: error.stack },
+      })
+    );
     return NextResponse.json(
       { error: "Failed to create promotion" },
       { status: 500 }

--- a/utils/firebaseAdmin.js
+++ b/utils/firebaseAdmin.js
@@ -45,6 +45,13 @@ export async function verifyAuthToken(request) {
     });
     decoded = payload;
   } catch {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        msg: "auth token rejected",
+        path: new URL(request.url).pathname,
+      })
+    );
     return {
       error: NextResponse.json(
         { error: "Invalid or expired token" },
@@ -56,12 +63,26 @@ export async function verifyAuthToken(request) {
   try {
     const authorizedEmails = await getAuthorizedEmails();
     if (!decoded.email || !authorizedEmails.includes(decoded.email)) {
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          msg: "unauthorized email rejected",
+          email: decoded.email || null,
+          path: new URL(request.url).pathname,
+        })
+      );
       return {
         error: NextResponse.json({ error: "Unauthorized" }, { status: 403 }),
       };
     }
   } catch (error) {
-    console.error("Failed to load authorized emails:", error);
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "failed to load authorized emails",
+        err: { message: error.message, stack: error.stack },
+      })
+    );
     return {
       error: NextResponse.json(
         { error: "Failed to verify authorization" },


### PR DESCRIPTION
## Summary
- Logs search params, result count, and duration on the motorcycle listing endpoint
- Logs actor (verified admin email) + entity details on motorcycle/promotion create, update, and delete
- Logs previously-silent auth rejections (invalid/expired token, unauthorized email not in whitelist)
- Converts existing `console.error` calls to structured JSON (message, code, stack) instead of prose strings

No new dependencies — uses `console.log/warn/error` with `JSON.stringify`, per request to keep this lightweight without introducing a logger library.

## Test plan
- [x] `yarn lint` passes (no new warnings/errors introduced)
- [ ] Spot-check logs in Vercel dashboard after merge for a real search/create/delete/auth-rejection flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)