### PR TITLE
fix(storefront): declutter nav, scrollable brand filters, restore listing search

### DIFF
--- a/app/components/motorkekal/ListingsBody.js
+++ b/app/components/motorkekal/ListingsBody.js
@@ -1,14 +1,23 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Spin } from "antd";
 import { useMotorcyclesPg as useMotorcycles } from "@/utils/hooks/useMotorcyclesPg";
+import { useDebounce } from "@/utils/hooks/useDebounce";
 import Pagination from "@/app/components/common/Pagination";
 import BikeCard from "./BikeCard";
 import { waLink } from "./waLink";
 
 const SORTS = ["Price: lowest first", "Price: highest first"];
+
+const SearchIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" />
+    <path d="M20 20l-3.5-3.5" strokeLinecap="round" />
+  </svg>
+);
 
 const ListingsBody = () => {
   const t = useTranslations("mk");
@@ -29,8 +38,10 @@ const ListingsBody = () => {
     brandOptions,
     selectedSort,
     selectedBrand,
+    searchTerm,
     onSortOptionChange,
     onBrandOptionChange,
+    onSearchChange,
     motorcycles,
     paginatedMotorcycles,
     loading,
@@ -45,6 +56,14 @@ const ListingsBody = () => {
   });
 
   const isAll = !selectedBrand;
+
+  // Keep typing responsive locally and only hit the API once the user pauses.
+  const [query, setQuery] = useState(searchFromHome ?? "");
+  const debouncedQuery = useDebounce(query, 300);
+
+  useEffect(() => {
+    if (debouncedQuery !== searchTerm) onSearchChange(debouncedQuery);
+  }, [debouncedQuery, searchTerm, onSearchChange]);
 
   return (
     <main>
@@ -63,8 +82,31 @@ const ListingsBody = () => {
       </section>
 
       <section className="wrap" style={{ paddingBottom: 76 }}>
-        {/* Brand filter chips */}
-        <div className="chips" style={{ marginBottom: 22 }}>
+        {/* Search */}
+        <div className="listing-search">
+          <SearchIcon />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={tl("searchPlaceholder")}
+            aria-label={tl("searchPlaceholder")}
+          />
+          {query ? (
+            <button
+              type="button"
+              className="listing-search__clear"
+              onClick={() => setQuery("")}
+              aria-label={tl("clearSearch")}
+            >
+              &times;
+            </button>
+          ) : null}
+        </div>
+
+        {/* Brand filter chips — one scrollable row, since the brand list keeps
+            growing and wrapping it swallowed the top of the grid. */}
+        <div className="chips chips--scroll" role="group" aria-label={tl("allBrands")}>
           <button
             className={`chip${isAll ? " chip--on" : ""}`}
             onClick={() => onBrandOptionChange(null)}

--- a/app/components/motorkekal/SiteHeader.js
+++ b/app/components/motorkekal/SiteHeader.js
@@ -10,7 +10,6 @@ import { waLink, WaIcon, FbIcon, FACEBOOK_URL } from "./waLink";
 const NAV = [
   { href: "/", key: "home" },
   { href: "/listing", key: "listings" },
-  { href: "/brands", key: "brands" },
   { href: "/promotions", key: "promotions" },
   { href: "/service", key: "ourServices" },
   { href: "/about-us", key: "aboutUs" },

--- a/app/components/motorkekal/motorkekal.css
+++ b/app/components/motorkekal/motorkekal.css
@@ -1021,6 +1021,113 @@
   flex-wrap: wrap;
   gap: 8px;
 }
+
+/* Single-row variant for the brand filter. The brand list grows over time and
+   wrapping it pushed the bike grid below the fold, so it scrolls sideways
+   instead. Edge fades hint that there is more to the right. */
+.mk-site .chips--scroll {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  /* Room for the focus ring, which overflow would otherwise clip. */
+  padding: 3px 0;
+  margin-bottom: 22px;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  /* Fade the trailing edge only, so the first chip is never clipped at rest. */
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent 100%);
+  mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent 100%);
+}
+.mk-site .chips--scroll::-webkit-scrollbar {
+  display: none;
+}
+.mk-site .chips--scroll > .chip {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+}
+/* Bleed to the viewport edges on small screens so the row reads as scrollable
+   rather than as a clipped block inside the page gutter. Values track the
+   .wrap gutter: 24px, dropping to 18px under 560px. */
+@media (max-width: 860px) {
+  .mk-site .chips--scroll {
+    margin-inline: -24px;
+    padding-inline: 24px;
+  }
+}
+@media (max-width: 560px) {
+  .mk-site .chips--scroll {
+    margin-inline: -18px;
+    padding-inline: 18px;
+  }
+}
+
+/* ---- Listing search ---------------------------------------------------- */
+.mk-site .listing-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 14px;
+  max-width: 520px;
+}
+.mk-site .listing-search > svg {
+  position: absolute;
+  left: 15px;
+  width: 18px;
+  height: 18px;
+  color: var(--kk-text-muted);
+  pointer-events: none;
+}
+.mk-site .listing-search input {
+  width: 100%;
+  height: 48px;
+  padding: 0 44px;
+  border-radius: 12px;
+  border: 1px solid var(--kk-border-strong);
+  background: #fff;
+  font-family: var(--kk-font);
+  font-size: 15px;
+  color: var(--kk-text);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.mk-site .listing-search input::placeholder {
+  color: var(--kk-text-muted);
+}
+.mk-site .listing-search input:focus {
+  border-color: var(--kk-ink);
+  box-shadow: 0 0 0 3px rgba(23, 24, 28, 0.08);
+}
+/* Suppress the native clear affordance; we render our own. */
+.mk-site .listing-search input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+.mk-site .listing-search__clear {
+  position: absolute;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--kk-text-muted);
+}
+.mk-site .listing-search__clear:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--kk-text);
+}
+@media (max-width: 700px) {
+  .mk-site .listing-search {
+    max-width: none;
+  }
+}
 .mk-site .chip {
   height: 38px;
   padding: 0 15px;

--- a/messages/en.json
+++ b/messages/en.json
@@ -389,7 +389,8 @@
       "browseAll": "Browse all brands",
       "needHelp": "Need help finding the right motorcycle?",
       "contactExperts": "Contact our experts"
-    }
+    },
+    "clearSearch": "Clear search"
   },
   "promotions": {
     "thisMonth": "This Month",

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -389,7 +389,8 @@
       "browseAll": "Lihat semua jenama",
       "needHelp": "Perlukan bantuan mencari motosikal yang sesuai?",
       "contactExperts": "Hubungi pakar kami"
-    }
+    },
+    "clearSearch": "Kosongkan carian"
   },
   "promotions": {
     "thisMonth": "Bulan Ini",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -389,7 +389,8 @@
       "browseAll": "浏览所有品牌",
       "needHelp": "需要帮助找到合适的摩托车吗？",
       "contactExperts": "联系我们的专家"
-    }
+    },
+    "clearSearch": "清除搜索"
   },
   "promotions": {
     "thisMonth": "本月",


### PR DESCRIPTION
Three small storefront fixes. No schema or API changes.

### 1. Remove Brands from the header nav
The bar was getting crowded. `/brands` and its `[brand]` pages are untouched and
still linked from the footer and the sitemap, so they keep their SEO value — this
only drops the header entry (desktop nav and mobile drawer share one `NAV` array).

### 2. Brand filter chips scroll horizontally
The brand list keeps growing and the wrapped block was spilling onto two rows and
pushing the bike grid below the fold. Now a single scrollable row:

- Full-bleed to the viewport edges under 860px so it reads as scrollable
- Trailing-edge fade only, so the leading "All" chip is never clipped at rest
- Scrollbar hidden, scroll-snap on, `overscroll-behavior-x: contain`
- Verified the **page itself never scrolls sideways** at 1280 / 768 / 390px

### 3. Restore the listing search box
The search input was dropped from the listing during the storefront redesign in
3736281 — `useMotorcyclesPg` still supported `search`, but nothing rendered an
input, so it was only reachable via a `?search=` URL. Rebuilt in the `.mk-site`
layer (the old `components/listing/SearchAndFilters.js` is legacy Bootstrap and
stays unused), debounced 300ms, with a clear button.

Verified filtering end to end: 18 bikes → 1 on "Yamaha" → 18 on clear → empty
state on no match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)