### PR TITLE
ci(prisma): allow both migrate workflows to be run manually

### DIFF
--- a/.github/workflows/prisma-migrate-preview.yml
+++ b/.github/workflows/prisma-migrate-preview.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     paths:
       - "prisma/**"
+  workflow_dispatch:
+    inputs:
+      neon_branch:
+        description: "Neon branch to migrate, e.g. preview/staging. Created from the parent if it doesn't exist."
+        required: true
+      dry_run:
+        description: "Only report pending migrations, don't apply them"
+        type: boolean
+        default: false
 
 jobs:
   migrate-preview:
@@ -23,13 +32,19 @@ jobs:
         uses: neondatabase/create-branch-action@v5
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch_name: preview/${{ github.head_ref }}
+          branch_name: ${{ inputs.neon_branch || format('preview/{0}', github.head_ref) }}
           database: verceldb
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - run: yarn install --frozen-lockfile
 
+      - name: Show pending migrations
+        run: npx prisma migrate status || true
+        env:
+          DATABASE_URL: ${{ steps.neon.outputs.db_url_with_pooler }}
+
       - name: Apply migrations to preview branch database
+        if: ${{ !inputs.dry_run }}
         run: npx prisma migrate deploy
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url_with_pooler }}

--- a/.github/workflows/prisma-migrate.yml
+++ b/.github/workflows/prisma-migrate.yml
@@ -5,11 +5,28 @@ on:
     branches: [main, staging]
     paths:
       - "prisma/**"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Which database to migrate"
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+      dry_run:
+        description: "Only report pending migrations, don't apply them"
+        type: boolean
+        default: false
 
 jobs:
   migrate:
     name: Run Prisma Migrations
     runs-on: ubuntu-latest
+
+    # On push the branch picks the database; on dispatch the operator does.
+    env:
+      TARGET: ${{ inputs.target || (github.ref_name == 'staging' && 'staging' || 'production') }}
 
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +38,13 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - name: Apply migrations to database
+      - name: Show pending migrations
+        run: npx prisma migrate status || true
+        env:
+          DATABASE_URL: ${{ env.TARGET == 'staging' && secrets.STAGING_DATABASE_URL || secrets.DATABASE_URL }}
+
+      - name: Apply migrations
+        if: ${{ !inputs.dry_run }}
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{ github.ref_name == 'staging' && secrets.STAGING_DATABASE_URL || secrets.DATABASE_URL }}
+          DATABASE_URL: ${{ env.TARGET == 'staging' && secrets.STAGING_DATABASE_URL || secrets.DATABASE_URL }}


### PR DESCRIPTION
## Why

Migrations only run on a push to \`main\`/\`staging\` or a PR, both gated on \`paths: prisma/**\`. When a database drifts out of sync there is no way to re-run them — which is exactly the situation the current preview builds are in, failing on \`promotions."discountType"\` since #74.

## What

Both workflows gain a \`workflow_dispatch\`:

**Prisma Migrate (Production)** — `target` choice of \`staging\` (uses \`STAGING_DATABASE_URL\`) or \`production\` (uses \`DATABASE_URL\`). Push behaviour is unchanged: the branch still picks the database.

**Prisma Migrate (Preview Branch)** — `neon_branch` input, e.g. \`preview/staging\`. On a PR it still derives \`preview/<head_ref>\`.

Both also gain:
- a `dry_run` boolean that stops after `prisma migrate status`, so you can see what's pending before applying anything
- a `Show pending migrations` step that always runs, so the log records the before state

## Note

`workflow_dispatch` only appears once the workflow file is on the default branch, which here is \`staging\` — the Run workflow button shows up after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)