### PR TITLE
fix(seo): unstyled FAQ page, localized subpage metadata, 301 for /en

### DIFF
--- a/app/[locale]/(listing)/(listing-styles)/listing/layout.js
+++ b/app/[locale]/(listing)/(listing-styles)/listing/layout.js
@@ -1,11 +1,31 @@
 import ItemListSchema from "@/app/components/seo/ItemListSchema";
 import { localeAlternates } from "@/utils/seoAlternates";
 
-export function generateMetadata({ params: { locale } }) {
-  return {
+const META = {
+  en: {
+    title: "Motorcycles For Sale Johor Bahru - Yamaha, Honda, KTM",
+    description:
+      "New motorcycles for sale at Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & more. Affordable prices with in-house financing. Motorcycle shop in JB.",
+  },
+  ms: {
     title: "Jual Motor Baru Johor Bahru - Yamaha, Kawasaki, Honda, KTM",
     description:
       "Senarai motor baru untuk dijual di Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & lain-lain. Harga motor murah, loan kedai tersedia. Kedai motor JB.",
+  },
+  zh: {
+    title: "新山摩托车出售 - Yamaha、Kawasaki、Honda、KTM",
+    description:
+      "新山 Johor Jaya 摩托车专卖店 Perniagaan Motor Kekal 全新摩托车出售，Yamaha、Kawasaki、Honda、KTM、Modenas 等品牌，价格实惠，提供店内贷款。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+  const alternates = localeAlternates("/listing", locale);
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "kedai jual motor johor bahru",
       "kedai jual motor near me",
@@ -18,12 +38,11 @@ export function generateMetadata({ params: { locale } }) {
       "kedai motor yamaha near me",
       "best motorcycle shop in jb",
     ],
-    alternates: localeAlternates("/listing", locale),
+    alternates,
     openGraph: {
-      title: "Jual Motor Baru - Perniagaan Motor Kekal, Johor Bahru",
-      description:
-        "Senarai motor baru Yamaha, Kawasaki, Honda, KTM. Harga terbaik di Johor Bahru. Loan kedai tersedia.",
-      url: "https://www.motorkekal.com/listing",
+      title: `${meta.title} | Perniagaan Motor Kekal`,
+      description: meta.description,
+      url: `https://www.motorkekal.com${alternates.canonical}`,
       type: "website",
     },
   };

--- a/app/[locale]/(listing)/(listing-styles)/listing/layout.js
+++ b/app/[locale]/(listing)/(listing-styles)/listing/layout.js
@@ -3,17 +3,17 @@ import { localeAlternates } from "@/utils/seoAlternates";
 
 const META = {
   en: {
-    title: "Motorcycles For Sale Johor Bahru - Yamaha, Honda, KTM",
+    title: "Motorcycles For Sale Johor Bahru",
     description:
       "New motorcycles for sale at Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & more. Affordable prices with in-house financing. Motorcycle shop in JB.",
   },
   ms: {
-    title: "Jual Motor Baru Johor Bahru - Yamaha, Kawasaki, Honda, KTM",
+    title: "Jual Motor Baru Johor Bahru",
     description:
       "Senarai motor baru untuk dijual di Perniagaan Motor Kekal, Johor Jaya. Yamaha, Kawasaki, Honda, KTM, Modenas & lain-lain. Harga motor murah, loan kedai tersedia. Kedai motor JB.",
   },
   zh: {
-    title: "新山摩托车出售 - Yamaha、Kawasaki、Honda、KTM",
+    title: "新山摩托车出售 - Yamaha、Honda",
     description:
       "新山 Johor Jaya 摩托车专卖店 Perniagaan Motor Kekal 全新摩托车出售，Yamaha、Kawasaki、Honda、KTM、Modenas 等品牌，价格实惠，提供店内贷款。",
   },

--- a/app/[locale]/(listing)/(listing-styles)/listing/page.js
+++ b/app/[locale]/(listing)/(listing-styles)/listing/page.js
@@ -1,13 +1,48 @@
+import { Suspense } from "react";
+import { setRequestLocale } from "next-intl/server";
+import { useTranslations } from "next-intl";
 import SiteHeader from "@/app/components/motorkekal/SiteHeader";
 import SiteFooter from "@/app/components/motorkekal/SiteFooter";
 import MobileBar from "@/app/components/motorkekal/MobileBar";
 import ListingsBody from "@/app/components/motorkekal/ListingsBody";
 
-const ListingV1 = () => {
+const ListingV1 = ({ params: { locale } }) => {
+  setRequestLocale(locale);
+  const t = useTranslations("mk");
+  const tl = useTranslations("listing");
+
   return (
     <div className="mk-site">
       <SiteHeader />
-      <ListingsBody />
+
+      <main>
+        <div className="wrap">
+          <nav className="crumbs" aria-label="Breadcrumb">
+            <a href="/">{tl("breadcrumbHome")}</a>
+            <span>›</span>
+            {tl("breadcrumbCurrent")}
+          </nav>
+        </div>
+
+        <section className="page-hero wrap">
+          <p className="eyebrow">{t("listings.eyebrow")}</p>
+          <h1>{tl("breadcrumbTitle")}</h1>
+          <p>{t("listings.subtitle")}</p>
+        </section>
+
+        {/* ListingsBody reads useSearchParams(); without this boundary Next
+            deopts the whole route into client-side rendering. */}
+        <Suspense
+          fallback={
+            <section className="wrap" style={{ paddingBottom: 76 }}>
+              <div className="mk-center" />
+            </section>
+          }
+        >
+          <ListingsBody />
+        </Suspense>
+      </main>
+
       <SiteFooter />
       <MobileBar waMessage="Hi Motor Kekal, saya cari motosikal. Boleh bantu?" />
     </div>

--- a/app/[locale]/(listing)/(listing-styles)/listing/page.js
+++ b/app/[locale]/(listing)/(listing-styles)/listing/page.js
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { setRequestLocale } from "next-intl/server";
 import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
 import SiteHeader from "@/app/components/motorkekal/SiteHeader";
 import SiteFooter from "@/app/components/motorkekal/SiteFooter";
 import MobileBar from "@/app/components/motorkekal/MobileBar";
@@ -18,7 +19,7 @@ const ListingV1 = ({ params: { locale } }) => {
       <main>
         <div className="wrap">
           <nav className="crumbs" aria-label="Breadcrumb">
-            <a href="/">{tl("breadcrumbHome")}</a>
+            <Link href="/">{tl("breadcrumbHome")}</Link>
             <span>›</span>
             {tl("breadcrumbCurrent")}
           </nav>

--- a/app/[locale]/(pages)/about-us/page.js
+++ b/app/[locale]/(pages)/about-us/page.js
@@ -8,11 +8,30 @@ import Map from "@/app/components/common/Map";
 import { waLink, MAPS_QUERY_URL, ADDRESS, PHONE_DISPLAY } from "@/app/components/motorkekal/waLink";
 import { localeAlternates } from "@/utils/seoAlternates";
 
-export function generateMetadata({ params: { locale } }) {
-  return {
-    title: "Tentang Kami - Kedai Motor Johor Bahru | Perniagaan Motor Kekal",
+const META = {
+  en: {
+    title: "About Us - Kedai Motor Johor Bahru",
+    description:
+      "Perniagaan Motor Kekal is a family-run motorcycle shop in Johor Bahru, trusted for over 30 years. Yamaha, Kawasaki, Honda & KTM dealer — honest, friendly, local.",
+  },
+  ms: {
+    title: "Tentang Kami - Kedai Motor Johor Bahru",
     description:
       "Perniagaan Motor Kekal, kedai motor keluarga di Johor Bahru sejak lebih 30 tahun. Pengedar Yamaha, Kawasaki, Honda, KTM — jujur, mesra dan dipercayai orang JB.",
+  },
+  zh: {
+    title: "关于我们 - 新山摩托车行",
+    description:
+      "Perniagaan Motor Kekal 是新山一家超过30年的家族摩托车行。Yamaha、Kawasaki、Honda、KTM 经销商 — 诚信、亲切，深受新山人信赖。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "perniagaan motor kekal",
       "tentang motor kekal",

--- a/app/[locale]/(pages)/contact/page.js
+++ b/app/[locale]/(pages)/contact/page.js
@@ -13,11 +13,30 @@ import {
 } from "@/app/components/motorkekal/waLink";
 import { localeAlternates } from "@/utils/seoAlternates";
 
-export function generateMetadata({ params: { locale } }) {
-  return {
+const META = {
+  en: {
+    title: "Contact Us - Kedai Motor Johor Jaya, JB",
+    description:
+      "Contact Perniagaan Motor Kekal by phone or WhatsApp, or visit our shop in Taman Johor Bahru (Johor Jaya). Open daily 9am - 7pm, closed Friday.",
+  },
+  ms: {
     title: "Hubungi Kami - Kedai Motor Johor Jaya, JB",
     description:
       "Hubungi Perniagaan Motor Kekal: telefon, WhatsApp atau datang terus ke kedai kami di Taman Johor Bahru (Johor Jaya). Buka setiap hari 9 pagi - 7 malam, Jumaat tutup.",
+  },
+  zh: {
+    title: "联络我们 - 新山 Johor Jaya 摩托车行",
+    description:
+      "联络 Perniagaan Motor Kekal：电话、WhatsApp，或直接前往我们位于 Taman Johor Bahru（Johor Jaya）的店面。每日营业 9am - 7pm，星期五休息。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "kedai motor johor jaya",
       "kedai motor johor bahru contact",

--- a/app/[locale]/(pages)/motorcycles/page.js
+++ b/app/[locale]/(pages)/motorcycles/page.js
@@ -14,11 +14,30 @@ import { localeAlternates } from "@/utils/seoAlternates";
 // indexed" by making the pages discoverable, not just present in the sitemap).
 export const revalidate = 86400; // 24 hours
 
-export function generateMetadata({ params: { locale } }) {
-  return {
-    title: "All Motorcycles - Kedai Motor Johor Bahru | Perniagaan Motor Kekal",
+const META = {
+  en: {
+    title: "All Motorcycles - Kedai Motor Johor Bahru",
     description:
       "Browse every motorcycle for sale at Perniagaan Motor Kekal, Johor Bahru — Yamaha, Honda, Kawasaki, KTM and more. New bikes with easy financing and in-house servicing.",
+  },
+  ms: {
+    title: "Senarai Motosikal - Kedai Motor Johor Bahru",
+    description:
+      "Lihat semua motosikal untuk dijual di Perniagaan Motor Kekal, Johor Bahru — Yamaha, Honda, Kawasaki, KTM dan lain-lain. Motor baru, loan mudah lulus & servis bengkel sendiri.",
+  },
+  zh: {
+    title: "全部摩托车 - 新山摩托车行",
+    description:
+      "浏览 Perniagaan Motor Kekal（新山）所有待售摩托车 — Yamaha、Honda、Kawasaki、KTM 等。全新车款，贷款容易批准，并提供自家工作坊保养服务。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "all motorcycles johor bahru",
       "senarai motosikal",

--- a/app/[locale]/(pages)/promotions/page.js
+++ b/app/[locale]/(pages)/promotions/page.js
@@ -18,17 +18,17 @@ const META = {
   en: {
     title: "Motorcycle Promotions Johor Bahru",
     description:
-      "Limited-time deals on new motorcycles, servicing and trade-ins in Johor Jaya, JB. See the latest Motor Kekal promotions — visit the showroom to claim.",
+      "Limited-time deals on new motorcycles, servicing and trade-ins in Johor Jaya, JB. See the latest Perniagaan Motor Kekal promotions — visit the showroom.",
   },
   ms: {
     title: "Promosi Motor Johor Bahru - Tawaran & Diskaun",
     description:
-      "Tawaran terhad motor baru, servis & trade-in di Johor Jaya, JB. Lihat promosi terkini Kekal Motor dengan kira detik — datang showroom untuk claim.",
+      "Tawaran terhad motor baru, servis & trade-in di Johor Jaya, JB. Lihat promosi terkini Perniagaan Motor Kekal — datang showroom untuk claim.",
   },
   zh: {
     title: "新山摩托车促销优惠",
     description:
-      "新山 Johor Jaya 全新摩托车、保养与旧车换新限时优惠。查看 Motor Kekal 最新促销倒计时 — 亲临展厅即可领取。",
+      "新山 Johor Jaya 全新摩托车、保养与旧车换新限时优惠。查看 Perniagaan Motor Kekal 最新促销倒计时 — 亲临展厅即可领取。",
   },
 };
 

--- a/app/[locale]/(pages)/promotions/page.js
+++ b/app/[locale]/(pages)/promotions/page.js
@@ -14,11 +14,30 @@ import { localeAlternates } from "@/utils/seoAlternates";
 // ignored by the build anyway (page was fully frozen at deploy time).
 export const revalidate = 300;
 
-export function generateMetadata({ params: { locale } }) {
-  return {
-    title: "Promosi Motor Johor Bahru - Tawaran & Diskaun Kekal Motor",
+const META = {
+  en: {
+    title: "Motorcycle Promotions Johor Bahru",
+    description:
+      "Limited-time deals on new motorcycles, servicing and trade-ins in Johor Jaya, JB. See the latest Motor Kekal promotions — visit the showroom to claim.",
+  },
+  ms: {
+    title: "Promosi Motor Johor Bahru - Tawaran & Diskaun",
     description:
       "Tawaran terhad motor baru, servis & trade-in di Johor Jaya, JB. Lihat promosi terkini Kekal Motor dengan kira detik — datang showroom untuk claim.",
+  },
+  zh: {
+    title: "新山摩托车促销优惠",
+    description:
+      "新山 Johor Jaya 全新摩托车、保养与旧车换新限时优惠。查看 Motor Kekal 最新促销倒计时 — 亲临展厅即可领取。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "promosi motor johor bahru",
       "tawaran motor johor jaya",

--- a/app/[locale]/(pages)/service/page.js
+++ b/app/[locale]/(pages)/service/page.js
@@ -8,16 +8,42 @@ import Pill from "@/app/components/motorkekal/Pill";
 import { waLink } from "@/app/components/motorkekal/waLink";
 import { localeAlternates } from "@/utils/seoAlternates";
 
-export function generateMetadata({ params: { locale } }) {
-  return {
-    title: "Servis Motor Johor Bahru - Yamaha, Kawasaki Service Center",
+// The layout appends "| Perniagaan Motor Kekal", so titles stay short enough
+// that the whole thing survives the ~60-char SERP cut.
+const META = {
+  en: {
+    title: "Motorcycle Service Centre Johor Bahru",
     description:
-      "Pusat servis motor di Johor Bahru. Pembiayaan mudah lulus, tukar-beli, waranti & servis bengkel sendiri, insurans & renew cukai jalan. Semua bawah satu bumbung.",
+      "Motorcycle service centre in Johor Bahru — Yamaha, Kawasaki, Honda & KTM. Our own workshop with genuine parts, easy financing, trade-in, insurance & road tax renewal.",
+  },
+  ms: {
+    title: "Servis Motor Johor Bahru - Bengkel Sendiri",
+    description:
+      "Pusat servis motor di Johor Bahru. Bengkel sendiri, alat ganti asli. Pembiayaan mudah lulus, tukar-beli, waranti, insurans & renew cukai jalan bawah satu bumbung.",
+  },
+  zh: {
+    title: "新山摩托车维修保养中心",
+    description:
+      "新山摩托车维修保养中心 — Yamaha、Kawasaki、Honda、KTM。自家工作坊，原厂配件，另有贷款、旧车换新、保险与路税更新服务。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
+      "servis motor johor bahru",
+      "motorcycle service centre johor bahru",
+      "kawasaki service center johor bahru",
+      "yamaha service center near me",
+      "motorcycle repair shop near me",
+      "bengkel motor johor bahru",
       "pembiayaan motosikal johor bahru",
       "loan motor mudah lulus",
       "trade-in motor johor bahru",
-      "servis motor johor bahru",
       "insurans motor",
       "renew cukai jalan johor",
     ],
@@ -63,8 +89,22 @@ const Service = ({ params: { locale } }) => {
   const insurance = t.raw("insurance");
   const faq = t.raw("faq");
 
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: { "@type": "Answer", text: item.a },
+    })),
+  };
+
   return (
     <div className="mk-site">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
       <SiteHeader />
 
       <main>

--- a/app/[locale]/faq/FAQContent.js
+++ b/app/[locale]/faq/FAQContent.js
@@ -41,7 +41,7 @@ export default function FAQContent() {
   };
 
   return (
-    <div className="wrapper">
+    <div className="mk-site">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchemaData) }}

--- a/app/[locale]/faq/page.js
+++ b/app/[locale]/faq/page.js
@@ -4,11 +4,30 @@ import { localeAlternates } from "@/utils/seoAlternates";
 
 // Server wrapper so the FAQ page gets its own metadata — without this the
 // client component inherited the layout's, which canonicalized /faq to "/".
-export function generateMetadata({ params: { locale } }) {
-  return {
+const META = {
+  en: {
+    title: "FAQ - Motorcycle Loans, Delivery & Warranty",
+    description:
+      "Common questions about buying a motorcycle at Perniagaan Motor Kekal, Johor Bahru — financing and loans, documents needed, delivery, warranty and servicing.",
+  },
+  ms: {
     title: "FAQ - Loan Motor, Penghantaran & Waranti",
     description:
       "Soalan lazim pasal beli motor di Perniagaan Motor Kekal, Johor Bahru — pembiayaan & loan motor, dokumen diperlukan, penghantaran, waranti dan servis.",
+  },
+  zh: {
+    title: "常见问题 - 摩托车贷款、交车与保修",
+    description:
+      "在新山 Perniagaan Motor Kekal 购买摩托车的常见问题 — 贷款与融资、所需文件、交车、保修与保养服务。",
+  },
+};
+
+export function generateMetadata({ params: { locale } }) {
+  const meta = META[locale] || META.en;
+
+  return {
+    title: meta.title,
+    description: meta.description,
     keywords: [
       "loan motor johor bahru",
       "cara beli motor",

--- a/app/[locale]/motorcycle/[slug]/page.js
+++ b/app/[locale]/motorcycle/[slug]/page.js
@@ -52,7 +52,9 @@ export async function generateMetadata({ params }) {
     const priceLabel = `RM${Number(price).toLocaleString("en-MY")}`;
     // Nobody searches the model alone ("Demon 150GN") — the brand is what
     // makes the title match the query.
-    const fullName = motorcycleData.name.startsWith(motorcycleData.brand)
+    const fullName = motorcycleData.name
+      .toLowerCase()
+      .startsWith(motorcycleData.brand.toLowerCase())
       ? motorcycleData.name
       : `${motorcycleData.brand} ${motorcycleData.name}`;
 

--- a/app/[locale]/motorcycle/[slug]/page.js
+++ b/app/[locale]/motorcycle/[slug]/page.js
@@ -49,10 +49,16 @@ export async function generateMetadata({ params }) {
     const firstImage = motorcycleData.images?.[0]?.url;
     // So the search-result title never contradicts the price on the page.
     const price = motorcycleData.pricing?.price ?? motorcycleData.price;
+    const priceLabel = `RM${Number(price).toLocaleString("en-MY")}`;
+    // Nobody searches the model alone ("Demon 150GN") — the brand is what
+    // makes the title match the query.
+    const fullName = motorcycleData.name.startsWith(motorcycleData.brand)
+      ? motorcycleData.name
+      : `${motorcycleData.brand} ${motorcycleData.name}`;
 
     return {
-      title: `${motorcycleData.name} - RM${price}`,
-      description: `${motorcycleData.name} for sale at RM${price}. ${
+      title: `${fullName} - ${priceLabel}`,
+      description: `${fullName} for sale at ${priceLabel}. ${
         motorcycleData.description ||
         "Quality motorcycle from trusted dealer in Johor Bahru, Johor Jaya."
       }`,
@@ -71,8 +77,8 @@ export async function generateMetadata({ params }) {
       ],
       alternates: localeAlternates(`/motorcycle/${slug}`, params.locale),
       openGraph: {
-        title: `${motorcycleData.name} - RM${price}`,
-        description: `${motorcycleData.name} for sale at RM${price}. Trusted motorcycle dealer in Johor Bahru.`,
+        title: `${fullName} - ${priceLabel}`,
+        description: `${fullName} for sale at ${priceLabel}. Trusted motorcycle dealer in Johor Bahru.`,
         url: `https://www.motorkekal.com/motorcycle/${slug}`,
         siteName: "Perniagaan Motor Kekal",
         type: "website",

--- a/app/components/motorkekal/ListingsBody.js
+++ b/app/components/motorkekal/ListingsBody.js
@@ -131,185 +131,169 @@ const ListingsBody = () => {
   );
 
   return (
-    <main>
-      <div className="wrap">
-        <nav className="crumbs" aria-label="Breadcrumb">
-          <a href="/">{tl("breadcrumbHome")}</a>
-          <span>›</span>
-          {tl("breadcrumbCurrent")}
-        </nav>
+    <section className="wrap" style={{ paddingBottom: 76 }}>
+      {searchBox("listing-search--standalone")}
+
+      {/* Brand filter chips — one clipped row paged by the arrows, since the
+          brand list keeps growing and wrapping it swallowed the top of the
+          grid. */}
+      <div className="chip-rail">
+        {!atStart ? (
+          <button
+            type="button"
+            className="chip-rail__nav chip-rail__nav--prev"
+            onClick={() => pageRail(-1)}
+            aria-label={tl("brandsPrev")}
+          >
+            <ChevronIcon dir="prev" />
+          </button>
+        ) : null}
+        <div
+          ref={railRef}
+          onScroll={syncRail}
+          className={`chips chips--scroll${!atStart ? " is-start" : ""}${
+            !atEnd ? " is-end" : ""
+          }`}
+          role="group"
+          aria-label={tl("allBrands")}
+        >
+          <button
+            className={`chip${isAll ? " chip--on" : ""}`}
+            onClick={() => onBrandOptionChange(null)}
+          >
+            {t("listings.all")}
+          </button>
+          {brandOptions.map((b) => (
+            <button
+              key={b.value}
+              className={`chip${selectedBrand === b.label ? " chip--on" : ""}`}
+              onClick={() => onBrandOptionChange({ label: b.label })}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+        {!atEnd ? (
+          <button
+            type="button"
+            className="chip-rail__nav chip-rail__nav--next"
+            onClick={() => pageRail(1)}
+            aria-label={tl("brandsNext")}
+          >
+            <ChevronIcon dir="next" />
+          </button>
+        ) : null}
       </div>
 
-      <section className="page-hero wrap">
-        <p className="eyebrow">{t("listings.eyebrow")}</p>
-        <h1>{tl("breadcrumbTitle")}</h1>
-        <p>{t("listings.subtitle")}</p>
-      </section>
-
-      <section className="wrap" style={{ paddingBottom: 76 }}>
-        {searchBox("listing-search--standalone")}
-
-        {/* Brand filter chips — one clipped row paged by the arrows, since the
-            brand list keeps growing and wrapping it swallowed the top of the
-            grid. */}
-        <div className="chip-rail">
-          {!atStart ? (
-            <button
-              type="button"
-              className="chip-rail__nav chip-rail__nav--prev"
-              onClick={() => pageRail(-1)}
-              aria-label={tl("brandsPrev")}
+      <div className="listing-toolbar">
+        <p className="count">
+          {tl.rich("foundCount", {
+            count: motorcycles.length,
+            highlight: (chunks) => <b>{chunks}</b>,
+          })}
+        </p>
+        <div className="listing-toolbar__controls">
+          {searchBox()}
+          <label className="chip" style={{ cursor: "pointer" }}>
+            {tl("sortBy")}:
+            <select
+              value={selectedSort}
+              onChange={(e) => onSortOptionChange({ value: e.target.value })}
+              style={{
+                border: "none",
+                background: "transparent",
+                fontFamily: "var(--kk-font)",
+                fontSize: 14,
+                fontWeight: 500,
+                color: "inherit",
+                cursor: "pointer",
+                outline: "none",
+              }}
             >
-              <ChevronIcon dir="prev" />
-            </button>
-          ) : null}
-          <div
-            ref={railRef}
-            onScroll={syncRail}
-            className={`chips chips--scroll${!atStart ? " is-start" : ""}${
-              !atEnd ? " is-end" : ""
-            }`}
-            role="group"
-            aria-label={tl("allBrands")}
-          >
-            <button
-              className={`chip${isAll ? " chip--on" : ""}`}
-              onClick={() => onBrandOptionChange(null)}
-            >
-              {t("listings.all")}
-            </button>
-            {brandOptions.map((b) => (
-              <button
-                key={b.value}
-                className={`chip${selectedBrand === b.label ? " chip--on" : ""}`}
-                onClick={() => onBrandOptionChange({ label: b.label })}
-              >
-                {b.label}
-              </button>
-            ))}
-          </div>
-          {!atEnd ? (
-            <button
-              type="button"
-              className="chip-rail__nav chip-rail__nav--next"
-              onClick={() => pageRail(1)}
-              aria-label={tl("brandsNext")}
-            >
-              <ChevronIcon dir="next" />
-            </button>
-          ) : null}
+              <option value={SORTS[0]}>{tl("priceLowToHigh")}</option>
+              <option value={SORTS[1]}>{tl("priceHighToLow")}</option>
+            </select>
+          </label>
         </div>
+      </div>
 
-        <div className="listing-toolbar">
-          <p className="count">
-            {tl.rich("foundCount", {
-              count: motorcycles.length,
-              highlight: (chunks) => <b>{chunks}</b>,
-            })}
-          </p>
-          <div className="listing-toolbar__controls">
-            {searchBox()}
-            <label className="chip" style={{ cursor: "pointer" }}>
-              {tl("sortBy")}:
-              <select
-                value={selectedSort}
-                onChange={(e) => onSortOptionChange({ value: e.target.value })}
-                style={{
-                  border: "none",
-                  background: "transparent",
-                  fontFamily: "var(--kk-font)",
-                  fontSize: 14,
-                  fontWeight: 500,
-                  color: "inherit",
-                  cursor: "pointer",
-                  outline: "none",
-                }}
-              >
-                <option value={SORTS[0]}>{tl("priceLowToHigh")}</option>
-                <option value={SORTS[1]}>{tl("priceHighToLow")}</option>
-              </select>
-            </label>
-          </div>
+      {loading ? (
+        <div className="mk-center">
+          <Spin size="large" />
         </div>
-
-        {loading ? (
-          <div className="mk-center">
-            <Spin size="large" />
-          </div>
-        ) : motorcycles.length === 0 ? (
-          <div
-            className="card card--pad"
-            style={{ textAlign: "center", padding: 48 }}
-          >
-            <h3 style={{ fontSize: 20 }}>{tl("empty.title")}</h3>
-            <p className="muted" style={{ marginTop: 8 }}>
-              {tl("empty.subtitle")}
-            </p>
-          </div>
-        ) : (
-          <div className="bike-grid">
-            {paginatedMotorcycles.map((m) => (
-              <BikeCard key={m.id} motorcycle={m} />
-            ))}
-          </div>
-        )}
-
-        {/* Can't find CTA */}
+      ) : motorcycles.length === 0 ? (
         <div
           className="card card--pad"
-          style={{
-            marginTop: 26,
-            borderStyle: "dashed",
-            borderColor: "var(--kk-border-strong)",
-            display: "flex",
-            gap: 16,
-            alignItems: "center",
-            flexWrap: "wrap",
-            justifyContent: "space-between",
-          }}
+          style={{ textAlign: "center", padding: 48 }}
         >
-          <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-            <div className="svc-card__ico" style={{ width: 46, height: 46 }}>
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path
-                  d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </div>
-            <div>
-              <h3 style={{ fontSize: 18 }}>{t("listings.cantFindTitle")}</h3>
-              <p
-                className="muted"
-                style={{ marginTop: 4, fontSize: "14.5px", maxWidth: "44ch" }}
-              >
-                {t("listings.cantFindBody")}
-              </p>
-            </div>
-          </div>
-          <a
-            className="btn btn--wa"
-            href={waLink(
-              "Hi Motor Kekal, saya cari model ______. Ada tak / boleh source tak?"
-            )}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t("listings.cantFindCta")}
-          </a>
+          <h3 style={{ fontSize: 20 }}>{tl("empty.title")}</h3>
+          <p className="muted" style={{ marginTop: 8 }}>
+            {tl("empty.subtitle")}
+          </p>
         </div>
+      ) : (
+        <div className="bike-grid">
+          {paginatedMotorcycles.map((m) => (
+            <BikeCard key={m.id} motorcycle={m} />
+          ))}
+        </div>
+      )}
 
-        {totalPages > 1 && (
-          <div style={{ marginTop: 30 }}>
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              setCurrentPage={setCurrentPage}
-            />
+      {/* Can't find CTA */}
+      <div
+        className="card card--pad"
+        style={{
+          marginTop: 26,
+          borderStyle: "dashed",
+          borderColor: "var(--kk-border-strong)",
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          flexWrap: "wrap",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
+          <div className="svc-card__ico" style={{ width: 46, height: 46 }}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path
+                d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z"
+                strokeLinejoin="round"
+              />
+            </svg>
           </div>
-        )}
-      </section>
-    </main>
+          <div>
+            <h3 style={{ fontSize: 18 }}>{t("listings.cantFindTitle")}</h3>
+            <p
+              className="muted"
+              style={{ marginTop: 4, fontSize: "14.5px", maxWidth: "44ch" }}
+            >
+              {t("listings.cantFindBody")}
+            </p>
+          </div>
+        </div>
+        <a
+          className="btn btn--wa"
+          href={waLink(
+            "Hi Motor Kekal, saya cari model ______. Ada tak / boleh source tak?"
+          )}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t("listings.cantFindCta")}
+        </a>
+      </div>
+
+      {totalPages > 1 && (
+        <div style={{ marginTop: 30 }}>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            setCurrentPage={setCurrentPage}
+          />
+        </div>
+      )}
+    </section>
   );
 };
 

--- a/app/components/seo/ProductSchema.js
+++ b/app/components/seo/ProductSchema.js
@@ -8,6 +8,7 @@ const ProductSchema = ({ motorcycle }) => {
     "@context": "https://schema.org",
     "@type": "Product",
     name: motorcycle.name,
+    sku: motorcycle.id,
     url,
     description:
       motorcycle.description ||

--- a/middleware.js
+++ b/middleware.js
@@ -19,6 +19,16 @@ export function middleware(request) {
     return NextResponse.redirect(url, 301);
   }
 
+  // next-intl strips the redundant "/en" prefix with a 307, which doesn't pass
+  // ranking signals — and Google has indexed ~60 "/en/..." URLs. Redirect them
+  // permanently instead so they consolidate onto the prefix-free canonical.
+  const { pathname } = request.nextUrl;
+  if (pathname === "/en" || pathname.startsWith("/en/")) {
+    const url = request.nextUrl.clone();
+    url.pathname = pathname.slice(3) || "/";
+    return NextResponse.redirect(url, 301);
+  }
+
   // Delegate locale detection / prefixing to next-intl
   return intlMiddleware(request);
 }

--- a/middleware.js
+++ b/middleware.js
@@ -26,7 +26,11 @@ export function middleware(request) {
   if (pathname === "/en" || pathname.startsWith("/en/")) {
     const url = request.nextUrl.clone();
     url.pathname = pathname.slice(3) || "/";
-    return NextResponse.redirect(url, 301);
+    const res = NextResponse.redirect(url, 301);
+    // Bypassing next-intl skips its NEXT_LOCALE write, so an existing ms/zh
+    // cookie would bounce the visitor straight back off the English page.
+    res.cookies.set("NEXT_LOCALE", "en", { path: "/" });
+    return res;
   }
 
   // Delegate locale detection / prefixing to next-intl

--- a/tests/faq.spec.js
+++ b/tests/faq.spec.js
@@ -40,7 +40,9 @@ test.describe("FAQ Page - Desktop", () => {
   });
 
   test("should show WhatsApp CTA at bottom", async ({ page }) => {
-    const waLink = page.locator('a[href*="wa.me"]');
+    // Scoped to the page's own CTA — the header's wa.me button is hidden below
+    // the desktop breakpoint, so an unscoped .first() picks that on mobile.
+    const waLink = page.locator('a[class*="bottomBtn"][href*="wa.me"]');
     await expect(waLink.first()).toBeVisible();
   });
 


### PR DESCRIPTION
Audited the site against a 3-month Search Console export (13,498 mobile + 2,003 desktop impressions, avg position ~8, **0.65% CTR**). The site ranks on page one but barely gets clicked, so this PR targets snippets, locale coverage and one broken page — not rankings.

## 6. `/listing` was broken in production — fixed

`/listing`, `/ms/listing` and `/zh/listing` all served Next's CSR-bailout document: **HTTP 200, no `<title>`, no canonical, no content**. Google saw a soft error on the main nav's Listings destination, a priority-0.9 sitemap entry and the `/listing-single-v1/*` 301 target.

Reproduced against a local production build (dev mode renders it fine, which is why it went unnoticed):

```
warn Entire page /[locale]/listing deopted into client-side rendering.
```

`ListingsBody` calls `useSearchParams()` (line 35) and the route had no `<Suspense>` boundary, so Next bailed the entire route out of server rendering. Regression from 68e454e, which rewrote `ListingsBody.js`.

Fix: the breadcrumbs and hero move up into `page.js` as a server component (`setRequestLocale` + `useTranslations`, same pattern as `/service`) so the prerendered HTML carries the `h1` and copy, and `ListingsBody` sits behind `<Suspense>`. The deopt warning is gone from the build and all three locales now return title, canonical, localized `h1` and `ItemList` schema.

While the page was rendering again, its layout was also the last one still serving Malay metadata to every locale, so it gets the same per-locale `META` map as the pages below, with `openGraph` following the locale-aware canonical.

## What else is in this PR


### 1. FAQ page was completely unstyled in production

`FAQContent.js` used `className="wrapper"` (legacy Bootstrap theme) while rendering storefront components — `SiteHeader`, `SiteFooter`, `MobileBar` — whose 317 CSS rules are all scoped under `.mk-site`. None applied: the header collapsed to plain text links and the footer's Facebook SVG filled the whole viewport. Regression from cf95806, which moved FAQ onto the storefront components but kept the old wrapper class. Verified `faq.module.css` never referenced `.wrapper`, so the swap is safe. Checked every other page using `SiteHeader` — FAQ was the only one affected.

### 2. `ms` / `zh` subpages served non-native metadata

These locales have the site's **best CTR — 3.56% (zh) and 2.28% (ms) vs 0.66% for en** — but every subpage served English/Malay titles. Added per-locale title/description to `service`, `motorcycles`, `about-us`, `contact`, `faq` and `promotions`, following the pattern already used in `brands/page.js` and the zh homepage.

### 3. `/en/*` redirected with 307 instead of 301

next-intl strips the redundant `/en` prefix with a temporary redirect, which passes no ranking signals — and Google has indexed **~60 `/en/...` URLs** that compete with their canonical prefix-free versions. `/en/faq` is the only way the FAQ page appears in GSC at all (15 impressions, 0 clicks). Now a 301. Verified `/enquiry` and `/ens` still pass through untouched.

### 4. `/service` strengthened

3,403 impressions → 11 clicks (**0.32% CTR**) at position 8.8, ranking for `kawasaki service center johor bahru`, `yamaha service center near me`, `motorcycle repair shop near me`. Added `FAQPage` schema for the 5 FAQs already rendered on the page, and retitled around those service queries.

### 5. Detail page titles now include the brand

Titles rendered as `Demon 150GN - RM8800`, omitting the brand nobody omits when searching (GSC has `jetx150` for a SYM bike). Now `GPX Demon 150GN - RM8,800`, with the price formatted via the existing `toLocaleString("en-MY")` convention. Also added `sku` to Product schema — only 3 clicks from 561 product-snippet impressions.

## Business name left intact

Titles keep the full **"Perniagaan Motor Kekal"** throughout, including the layout title template, per explicit instruction — even where that pushes past the ~60-char SERP cut. Page-level titles were still shortened, which removes the *duplicated* brand on `/motorcycles` and `/about-us` (previously 91 and 88 chars with the name twice).

## Verification

- `yarn lint` clean — the 2 remaining warnings are pre-existing in untouched files
- Full `yarn test:e2e` run against the branch: **125 passed, 1 failed**, and the one failure (`navigation.spec.js` › About Us) reproduces identically with the branch stashed, so it is a pre-existing local flake, not a regression. The FAQ WhatsApp CTA test that was red in CI now passes on both `desktop` and `mobile`
- Production build + `yarn start`, then confirmed `/listing`, `/ms/listing` and `/zh/listing` return the correct localized title, canonical, `og:url` and `h1` with no error boundary
- Rendered `/faq`, `/service`, `/about-us`, `/contact`, `/promotions` across `en`/`ms`/`zh` against a local dev server; all return correct localized titles with no error boundary
- Confirmed the styled FAQ page visually at desktop (1200px) and mobile (390px)
- Confirmed `FAQPage` schema emits 5 questions on `/service`
- Confirmed `/en/faq`, `/en/service`, `/en` return 301 and `/enquiry` still 404s



:robot: Generated with [Claude Code](https://claude.com/claude-code)
