### PR TITLE
chore: local Postgres for development, and clean up Neon preview branches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL=postgresql://user:password@host:5432/dbname?sslmode=require
+DATABASE_URL=postgresql://postgres:dev@localhost:5433/kekal
 
 # Firebase Client SDK (public, safe to expose in browser)
 NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key

--- a/.github/workflows/neon-delete-preview-branch.yml
+++ b/.github/workflows/neon-delete-preview-branch.yml
@@ -1,0 +1,25 @@
+name: Neon Delete Preview Branch
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - "prisma/**"
+  workflow_dispatch:
+    inputs:
+      neon_branch:
+        description: "Neon branch to delete, e.g. preview/staging"
+        required: true
+
+jobs:
+  delete-preview-branch:
+    name: Delete Neon Preview Branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: ${{ inputs.neon_branch || format('preview/{0}', github.head_ref) }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Motorcycle ecommerce platform for Perniagaan Motor Kekal, a motorcycle dealer in
 
 - Node.js 16+
 - Yarn
-- PostgreSQL database
+- Docker (for the local Postgres) or a PostgreSQL database
 - Firebase project
 
 ### Setup
@@ -26,8 +26,10 @@ git clone https://github.com/kaicong12/Kekal.git
 cd Kekal
 yarn install
 cp .env.example .env   # Fill in DATABASE_URL and Firebase config
+docker compose up -d   # Local Postgres on :5433
 npx prisma generate
 npx prisma migrate dev
+node tests/seed.js      # Optional: deterministic sample rows
 yarn dev                # http://localhost:3000
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: kekal-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: kekal
+    ports:
+      - "5433:5432"
+    volumes:
+      - kekal-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d kekal"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  kekal-pgdata:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.6.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "yarn db:up && next dev",
+    "db:up": "[ -n \"$CI\" ] || docker compose up -d --wait",
+    "db:down": "docker compose stop",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Why

Neon bills compute by **how long an endpoint stays awake**, not by query count, and autosuspend has a five-minute floor. A dev server holding a connection open keeps the endpoint billing for the whole working day, which is where most of our compute hours were going. Two changes here: move local development off Neon entirely, and stop leaking preview branches.

Worth noting for anyone reading the history: the earlier build-query memoization (#75) cut queries by 95% but barely moved compute hours, because the endpoint stayed awake for the same build duration. It was a latency win, not a billing one.

## Local Postgres

- `docker-compose.yml` — `postgres:17` with a named volume and a healthcheck.
- `yarn dev` now runs `db:up && next dev`, so it stays one command. `--wait` blocks on the healthcheck so Next never starts against a database that isn't accepting connections yet.
- `db:up` no-ops when `$CI` is set. This matters: `playwright.config.js` uses `yarn dev` as its `webServer`, and `e2e-tests.yml` points at Neon staging — without the guard every CI run would try to start Docker on the runner.
- Published on **5433**, not 5432. A host-native Postgres on the default port silently shadows the container (Docker binds the wildcard, `localhost` resolves to loopback first), which is a genuinely confusing failure mode.

Timings: 5.9s cold start, 0.7s when already up, 0.03s under CI.

## Neon preview branch cleanup

`prisma-migrate-preview.yml` creates `preview/<head_ref>` on every PR touching `prisma/**`, and nothing ever deleted them. Each carries its own compute endpoint billing independently. The new workflow mirrors the create workflow's `paths` filter and `workflow_dispatch` shape.

## Verification

Rebuilt from an empty volume following the README, then restored a copy of production data (211 motorcycles, 1166 images):

- All 7 migrations apply cleanly from scratch
- Full Playwright suite: **124/126 passed**
- `/`, `/listing`, `/promotions`, `/admin`, and a detail page all 200
- `/api/motorcycles` returns 211 across 20 brands; `search=honda` returns 26
- `mode: "insensitive"` works — this is PostgreSQL-only, and is the main reason SQLite was rejected as the local option
- Zero errors and zero `neon.tech` connections in the dev log; `pg_stat_activity` confirms traffic hitting the container

The 2 failures were `navigation.spec.js` About Us and Service on desktop — first-hit route compilation exceeding the 30s timeout under 4 parallel workers. They pass 6/6 in isolation. Pre-existing and unrelated; CI masks it with `retries: 2`.

## Follow-ups not in this PR

- `playwright.config.js` runs `yarn dev` rather than a built server, which is the root of that flakiness and holds the staging endpoint open longer than necessary on every PR.
- A `yarn db:refresh` script to pull a production snapshot into local would make the setup self-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)