### PR TITLE
test(nav): point About Us / Our Services checks at the footer

### DIFF
--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -3,17 +3,23 @@ const { test, expect } = require("@playwright/test");
 const { mockApiRoutes } = require("./mocks");
 
 test.describe("Navigation - Desktop", () => {
+  // About Us / Our Services were dropped from the header nav to reduce
+  // crowding; they're still reachable from the footer on every viewport.
   test("should navigate to About Us page", async ({ page }) => {
     await mockApiRoutes(page);
     await page.goto("/");
-    await page.getByRole("link", { name: "About Us" }).first().click();
+    const link = page.locator("footer").getByRole("link", { name: "About Us" });
+    await link.scrollIntoViewIfNeeded();
+    await link.click();
     await expect(page).toHaveURL(/\/about-us/);
   });
 
   test("should navigate to Service page", async ({ page }) => {
     await mockApiRoutes(page);
     await page.goto("/");
-    await page.getByRole("link", { name: /Our Services/i }).first().click();
+    const link = page.locator("footer").getByRole("link", { name: /Our Services/i }).first();
+    await link.scrollIntoViewIfNeeded();
+    await link.click();
     await expect(page).toHaveURL(/\/service/);
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #85. That PR intentionally dropped About Us / Our Services from the desktop header nav to reduce crowding (still reachable from the footer on every viewport). `navigation.spec.js` matched those links by accessible name across the whole page, so once the header copy was gone the locator fell through to the footer link via an implicit `.first()` — occasionally racing against scroll/hydration timing in CI (flagged as flaky on #85's run, both desktop and mobile).

- Scopes the locator to `footer` explicitly (matches actual intent post-#85).
- Calls `scrollIntoViewIfNeeded()` before clicking so the wait is deterministic instead of relying on an implicit auto-scroll during click.

`tests/listing.spec.js`'s "keeps every chip on a single row" flake (also seen on #85's run) is unrelated — confirmed by re-running it repeatedly in isolation, always green. It's pre-existing dev-server-under-parallel-load flakiness, not something #85 introduced, so left as-is.

## Test plan
- [x] `tests/navigation.spec.js` About Us / Service tests pass repeatedly, serially, on both desktop and mobile projects locally.
- [x] `npx eslint tests/navigation.spec.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)